### PR TITLE
Create dedicated service category pages

### DIFF
--- a/business-and-trade.html
+++ b/business-and-trade.html
@@ -1,0 +1,278 @@
+<!DOCTYPE html>
+<html lang="en-US" dir="ltr">
+
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+
+    <!-- ===============================================-->
+    <!--    Document Title-->
+    <!-- ===============================================-->
+    <title>Business &amp; Trade | PH Government Online</title>
+
+
+    <!-- ===============================================-->
+    <!--    Favicons-->
+    <!-- ===============================================-->
+    <link rel="apple-touch-icon" sizes="180x180" href="assets/img/favicons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/img/favicons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="assets/img/favicons/favicon-16x16.png">
+    <link rel="shortcut icon" type="image/x-icon" href="assets/img/favicons/favicon.ico">
+    <link rel="manifest" href="assets/img/favicons/manifest.json">
+    <meta name="msapplication-TileImage" content="assets/img/favicons/mstile-150x150.png">
+    <meta name="theme-color" content="#ffffff">
+
+
+    <!-- ===============================================-->
+    <!--    Stylesheets-->
+    <!-- ===============================================-->
+    <link href="assets/css/theme.css" rel="stylesheet" />
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VSNFJDN5JM"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-VSNFJDN5JM');
+    </script>
+  </head>
+
+
+  <body>
+
+    <!-- ===============================================-->
+    <!--    Main Content-->
+    <!-- ===============================================-->
+    <main class="main" id="top">
+      <nav class="navbar navbar-expand-lg navbar-light py-3 backdrop" data-navbar-on-scroll="data-navbar-on-scroll">
+        <div class="container"><a class="navbar-brand  mx-auto fw-bolder fs-2 fst-italic" href="index.html">
+           <img src="assets/img/logo.png" width="50px" alt="PH Online Services logo">
+            <span class="text-info">PH ONLINE</span>
+            <span class="text-warning">SERVICES</span>
+          </a>
+        </div>
+
+      </nav>
+
+      <section class="py-5 pt-0">
+        <div class="bg-holder d-none d-sm-block" style="background-image:url(assets/img/illustrations/category-bg.png);background-position:right top;background-size:200px 320px;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container mt-3">
+          <div class="row justify-content-center">
+            <div class="col-md-9 col-lg-8 text-center mb-3">
+              <h1 class="fw-bold fs-3 fs-lg-5 lh-sm mb-3">Business &amp; Trade</h1>
+              <p class="mb-4">Manage business registrations, intellectual property filings, compliance requirements and trade support services online.</p>
+              <a class="btn btn-outline-primary btn-sm" href="index.html#categorieslist">&larr; Back to all categories</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-5">
+        <div class="container">
+          <div class="main-list">
+            <div class="category mb-5">
+              <h4 class="mb-3">Business Copyright, Trademark and Patent</h4>
+              <div class="individual-service mb-2">
+                <a href="http://121.58.254.39:8080/sp-ui-tmefiling/wizard.htm?execution=e1s1" target="_blank" rel="noopener noreferrer">Apply for a Trademark Online</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://onlineservices.ipophil.gov.ph/eUMFile/" target="_blank" rel="noopener noreferrer">Apply for a Utility Model</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://onlineservices.ipophil.gov.ph/eIDFile/" target="_blank" rel="noopener noreferrer">File for IPOPHL Industrial Design</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://onlineservices.ipophil.gov.ph/eInventionFile/" target="_blank" rel="noopener noreferrer">Request for a Grant of a Philippine Patent</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="http://www.wipo.int/branddb/ph/en/" target="_blank" rel="noopener noreferrer">Search Trademark Information</a>
+              </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Business Registration, Certificates and Compliance</h4>
+              <div class="individual-service mb-2">
+                <a href="https://emb.gov.ph/issuance-of-certificate-of-conformity-coc-for-new-motor-vehicle-flowchart/" target="_blank" rel="noopener noreferrer">Apply for Certificate of Conformity</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://opms.emb.gov.ph/" target="_blank" rel="noopener noreferrer">Apply for Environmental Laboratory Recognition</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="http://www.erc.gov.ph/ContentPage/203" target="_blank" rel="noopener noreferrer">Apply for ERC Certificate of Compliance</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://opms.emb.gov.ph/" target="_blank" rel="noopener noreferrer">Apply for Importer and Importation Clearance for Recyclable Materials Containing Hazardous Substances</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://www.denr.gov.ph/index.php?id=352&amp;page=2&amp;sort=avl&amp;filter=creator&amp;filterID=43&amp;searchword=&amp;fromyear=&amp;frommonth=&amp;fromdate=&amp;toyear=&amp;tomonth=&amp;todate=&amp;dateval=" target="_blank" rel="noopener noreferrer">Apply for Non-CITES Wildlife Products - Import (Biodiversity Management)</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://opms.emb.gov.ph/" target="_blank" rel="noopener noreferrer">Apply for Pre-Manufacture and Pre-Importation Notification Certificate</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://opms.emb.gov.ph/" target="_blank" rel="noopener noreferrer">Apply for Priority Chemical List Compliance Certificate</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://opms.emb.gov.ph/" target="_blank" rel="noopener noreferrer">Apply for Waste Water Discharge Permit</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://www.sec.gov.ph/online-services/registration-calculator/" target="_blank" rel="noopener noreferrer">Calculate Registration Fee of Stock Corporation</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://bnrs.dti.gov.ph/cancellation" target="_blank" rel="noopener noreferrer">Cancel your Application for Business Name Registration</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://cnconline.emb.gov.ph/projectchecker/ApplicationTracking.aspx?View=0" target="_blank" rel="noopener noreferrer">Check Status of CNC Application Online</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://ecconline.emb.gov.ph/live/" target="_blank" rel="noopener noreferrer">Check Status of ECC Application Online</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://www.sec.gov.ph/online-services/sec-company-registration-system/" target="_blank" rel="noopener noreferrer">Inquire Company Registration System (CRS) Status Online</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://bnrs.dti.gov.ph/registration" target="_blank" rel="noopener noreferrer">Register a Business Name</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://bnrs.dti.gov.ph/pdf/download/application_form.pdf" target="_blank" rel="noopener noreferrer">Register a Sole Proprietorship Business</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://bnrs.dti.gov.ph/request-certification" target="_blank" rel="noopener noreferrer">Request for Business Name Certificate</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://bnrs.dti.gov.ph/renewal" target="_blank" rel="noopener noreferrer">Request for Renewal of Business Name</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://dhsud.gov.ph/" target="_blank" rel="noopener noreferrer">Request for Zoning Certification</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://secexpress.ph/" target="_blank" rel="noopener noreferrer">Request Securing Copies of Corporate and Partnership Documents</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://www.sec.gov.ph/online-services/sec-express-system/" target="_blank" rel="noopener noreferrer">Submit your Company’s General Information Sheet and/or Audited Financial Statements Online to SEC</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://bnrs.dti.gov.ph/update-information" target="_blank" rel="noopener noreferrer">Update Information of your Application for a Business Name</a>
+              </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Complaints</h4>
+              <div class="individual-service mb-2">
+                <a href="https://investservices.boi.gov.ph/" target="_blank" rel="noopener noreferrer">Apply for Online Investment Assistance</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://www.dti.gov.ph/consumers/complaints" target="_blank" rel="noopener noreferrer">File Complaints on Consumer Affair Service</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://boi.gov.ph/" target="_blank" rel="noopener noreferrer">Know more About Business or Investment-related Assistance</a>
+              </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Financial Assistance</h4>
+              <div class="individual-service mb-2">
+                <a href="https://www.dbp.ph/developmental-banking/" target="_blank" rel="noopener noreferrer">Apply for DBP ME and OBE Loan</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://www.dbp.ph/developmental-banking/" target="_blank" rel="noopener noreferrer">Apply for DBP mSME Loan</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://www.dbp.ph/developmental-banking/" target="_blank" rel="noopener noreferrer">Apply for DBP RLM Loan</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://www.dbp.ph/developmental-banking/" target="_blank" rel="noopener noreferrer">Apply for DBP-Credit Surety Fund</a>
+              </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Import and Export</h4>
+              <div class="individual-service mb-2">
+                <a href="https://ears.peza.gov.ph/#/input" target="_blank" rel="noopener noreferrer">Apply for Registration as Ecozone Enterprise or Ecozone Developer</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://drive.google.com/file/d/1lcDlvI5BHJh-a81o-uSVmlQLAwgF4hPa/view" target="_blank" rel="noopener noreferrer">Apply Online for Advance Rulings on Tariff Classification and Tariff Classification Dispute Rulings</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://finder.tariffcommission.gov.ph/" target="_blank" rel="noopener noreferrer">Search for Tariff</a>
+              </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Price Control Monitoring</h4>
+              <div class="individual-service mb-2">
+                <a href="https://www.dti.gov.ph/konsyumer/e-presyo/" target="_blank" rel="noopener noreferrer">Check the Prevailing Prices of Basic Necessities and Prime Commodities (ePresyo)</a>
+              </div>
+              <div class="individual-service mb-2">
+                <a href="https://nfa.gov.ph/buying-selling-price" target="_blank" rel="noopener noreferrer">Know the Buying and Selling Prices of Rice and Corn</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-0 bg-primary-gradient">
+        <div class="bg-holder" style="background-image:url(assets/img/illustrations/footer-bg.png);background-position:center;background-size:cover;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container">
+
+          <div class="row flex-center">
+            <div class="col-auto my-4">
+              <ul class="list-unstyled list-inline">
+                <li class="list-inline-item me-3"><a class="text-decoration-none" href="https://www.facebook.com/yudipotech/">
+                    <svg class="bi bi-facebook" xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="#1F3A63" viewBox="0 0 16 16">
+                      <path d="M16 8.049c0-4.446-3.582-8.05-8-8.05C3.58 0-.002 3.603-.002 8.05c0 4.017 2.926 7.347 6.75 7.951v-5.625h-2.03V8.05H6.75V6.275c0-2.017 1.195-3.131 3.022-3.131.876 0 1.791.157 1.791.157v1.98h-1.009c-.993 0-1.303.621-1.303 1.258v1.51h2.218l-.354 2.326H9.25V16c3.824-.604 6.75-3.934 6.75-7.951z"></path>
+                    </svg></a></li>
+              </ul>
+            </div>
+          </div>
+          <div class="row justify-content-center">
+            <div class="col-auto mb-2">
+              <p class="mb-0 fs--1 text-white my-2 text-center">&copy; 2022 YUDIPO TECH
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <!-- ===============================================-->
+    <!--    End of Main Content-->
+    <!-- ===============================================-->
+
+
+
+
+    <!-- ===============================================-->
+    <!--    JavaScripts-->
+    <!-- ===============================================-->
+    <script src="vendors/@popperjs/popper.min.js"></script>
+    <script src="vendors/bootstrap/bootstrap.min.js"></script>
+    <script src="vendors/is/is.min.js"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=window.scroll"></script>
+    <script src="assets/js/theme.js"></script>
+
+    <!-- Meta Pixel Code -->
+    <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '1556559851381406');
+      fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+      src="https://www.facebook.com/tr?id=1556559851381406&ev=PageView&noscript=1"
+    /></noscript>
+    <!-- End Meta Pixel Code -->
+
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,200;1,300;1,400&amp;display=swap" rel="stylesheet">
+  </body>
+
+</html>

--- a/certificates-and-ids.html
+++ b/certificates-and-ids.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en-US" dir="ltr">
+
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+
+    <!-- ===============================================-->
+    <!--    Document Title-->
+    <!-- ===============================================-->
+    <title>Certificates &amp; IDs | PH Government Online</title>
+
+
+    <!-- ===============================================-->
+    <!--    Favicons-->
+    <!-- ===============================================-->
+    <link rel="apple-touch-icon" sizes="180x180" href="assets/img/favicons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/img/favicons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="assets/img/favicons/favicon-16x16.png">
+    <link rel="shortcut icon" type="image/x-icon" href="assets/img/favicons/favicon.ico">
+    <link rel="manifest" href="assets/img/favicons/manifest.json">
+    <meta name="msapplication-TileImage" content="assets/img/favicons/mstile-150x150.png">
+    <meta name="theme-color" content="#ffffff">
+
+
+    <!-- ===============================================-->
+    <!--    Stylesheets-->
+    <!-- ===============================================-->
+    <link href="assets/css/theme.css" rel="stylesheet" />
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VSNFJDN5JM"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-VSNFJDN5JM');
+    </script>
+  </head>
+
+
+  <body>
+
+    <!-- ===============================================-->
+    <!--    Main Content-->
+    <!-- ===============================================-->
+    <main class="main" id="top">
+      <nav class="navbar navbar-expand-lg navbar-light py-3 backdrop" data-navbar-on-scroll="data-navbar-on-scroll">
+        <div class="container"><a class="navbar-brand  mx-auto fw-bolder fs-2 fst-italic" href="index.html">
+           <img src="assets/img/logo.png" width="50px" alt="PH Online Services logo">
+            <span class="text-info">PH ONLINE</span>
+            <span class="text-warning">SERVICES</span>
+          </a>
+        </div>
+
+      </nav>
+
+      <section class="py-5 pt-0">
+        <div class="bg-holder d-none d-sm-block" style="background-image:url(assets/img/illustrations/category-bg.png);background-position:right top;background-size:200px 320px;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container mt-3">
+          <div class="row justify-content-center">
+            <div class="col-md-9 col-lg-8 text-center mb-3">
+              <h1 class="fw-bold fs-3 fs-lg-5 lh-sm mb-3">Certificates &amp; IDs</h1>
+              <p class="mb-4">Get quick access to certificate requests, clearances, national IDs and more government-issued identification services.</p>
+              <a class="btn btn-outline-primary btn-sm" href="index.html#categorieslist">&larr; Back to all categories</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-5">
+        <div class="container">
+          <div class="main-list">
+            <div class="category mb-5">
+              <h4 class="mb-3">Certificates</h4>
+              <div class="individual-service mb-2"> <a href="http://www.dost.gov.ph/products-and-services/accreditation-and-certification.html" target="_blank" rel="noopener noreferrer">Apply for DOST Accreditation and Certification</a> </div>
+              <div class="individual-service mb-2"> <a href="https://sfu.dost.gov.ph" target="_blank" rel="noopener noreferrer">Avail Certification of Science and Technology-oriented Foundations</a> </div>
+              <div class="individual-service mb-2"> <a href="https://psa.gov.ph/civilregistration/problems-and-solutions" target="_blank" rel="noopener noreferrer">Know How to Correct Errors in your Civil Registry Documents</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.psaserbilis.com.ph/Default.aspx" target="_blank" rel="noopener noreferrer">Request a Birth Certificate via PSA Serbilis</a> </div>
+              <div class="individual-service mb-2"> <a href="https://psahelpline.ph/" target="_blank" rel="noopener noreferrer">Request a Birth Certificate via PSAHelpline.ph</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.psaserbilis.com.ph/Default.aspx" target="_blank" rel="noopener noreferrer">Request a Certificate of No Marriage Record (CENOMAR) via PSA Serbilis</a> </div>
+              <div class="individual-service mb-2"> <a href="https://psahelpline.ph/" target="_blank" rel="noopener noreferrer">Request a Certificate of No Marriage Record (CENOMAR) via PSAHelpline.ph</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.psaserbilis.com.ph/Default.aspx" target="_blank" rel="noopener noreferrer">Request a Death Certificate via PSA Serbilis</a> </div>
+              <div class="individual-service mb-2"> <a href="https://psahelpline.ph/" target="_blank" rel="noopener noreferrer">Request a Death Certificate via PSAHelpline.ph</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.psaserbilis.com.ph/Default.aspx" target="_blank" rel="noopener noreferrer">Request a Marriage Certificate via PSA Serbilis</a> </div>
+              <div class="individual-service mb-2"> <a href="https://psahelpline.ph/" target="_blank" rel="noopener noreferrer">Request a Marriage Certificate via PSAHelpline.ph</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Clearances</h4>
+              <div class="individual-service mb-2"> <a href="https://clearance.nbi.gov.ph/" target="_blank" rel="noopener noreferrer">Apply for NBI Multipurpose Clearance</a> </div>
+              <div class="individual-service mb-2"> <a href="https://clearance.nbi.gov.ph/" target="_blank" rel="noopener noreferrer">Renew NBI Multipurpose Clearance</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">IDs</h4>
+              <div class="individual-service mb-2"> <a href="https://owwa.gov.ph/?page_id=3821" target="_blank" rel="noopener noreferrer">Apply for OWWA OFW e-Card</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.postalidph.com/how-to-apply.html" target="_blank" rel="noopener noreferrer">Get a Postal ID</a> </div>
+              <div class="individual-service mb-2"> <a href="http://www.ncda.gov.ph/2009/07/apply-fo-pwd-id-card/" target="_blank" rel="noopener noreferrer">Get a PWD ID</a> </div>
+              <div class="individual-service mb-2"> <a href="https://psa.gov.ph/sites/default/files/attachments/aodao/article/Q%20%26%20A_Solo%20Parent%27s%20Welfare%20Act%20and%20Parental%20Leave.pdf" target="_blank" rel="noopener noreferrer">Get a Solo Parent ID</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.sss.gov.ph/sss/DownloadContent?fileName=SSSForms_UMID_Application.pdf" target="_blank" rel="noopener noreferrer">Get a UMID ID</a> </div>
+              <div class="individual-service mb-2"> <a href="https://register.philsys.gov.ph/#/eng" target="_blank" rel="noopener noreferrer">Register to the Philippine Identification System (PhilSys) or National ID</a></div>
+              <div class="individual-service mb-2">  <a href="http://ecard.owwa.gov.ph/applicationform/tracker.php" target="_blank" rel="noopener noreferrer">Track your OWWA OFW e-Card</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Voters</h4>
+              <div class="individual-service mb-2"> <a href="https://comelec.gov.ph/?r=VoterRegistration/VoterVerification/precinct_finder" target="_blank" rel="noopener noreferrer">Verify Your Voter Status and Voting Precinct Location</a> </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-0 bg-primary-gradient">
+        <div class="bg-holder" style="background-image:url(assets/img/illustrations/footer-bg.png);background-position:center;background-size:cover;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container">
+
+          <div class="row flex-center">
+            <div class="col-auto my-4">
+              <ul class="list-unstyled list-inline">
+                <li class="list-inline-item me-3"><a class="text-decoration-none" href="https://www.facebook.com/yudipotech/">
+                    <svg class="bi bi-facebook" xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="#1F3A63" viewBox="0 0 16 16">
+                      <path d="M16 8.049c0-4.446-3.582-8.05-8-8.05C3.58 0-.002 3.603-.002 8.05c0 4.017 2.926 7.347 6.75 7.951v-5.625h-2.03V8.05H6.75V6.275c0-2.017 1.195-3.131 3.022-3.131.876 0 1.791.157 1.791.157v1.98h-1.009c-.993 0-1.303.621-1.303 1.258v1.51h2.218l-.354 2.326H9.25V16c3.824-.604 6.75-3.934 6.75-7.951z"></path>
+                    </svg></a></li>
+              </ul>
+            </div>
+          </div>
+          <div class="row justify-content-center">
+            <div class="col-auto mb-2">
+              <p class="mb-0 fs--1 text-white my-2 text-center">&copy; 2022 YUDIPO TECH
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <!-- ===============================================-->
+    <!--    End of Main Content-->
+    <!-- ===============================================-->
+
+
+
+
+    <!-- ===============================================-->
+    <!--    JavaScripts-->
+    <!-- ===============================================-->
+    <script src="vendors/@popperjs/popper.min.js"></script>
+    <script src="vendors/bootstrap/bootstrap.min.js"></script>
+    <script src="vendors/is/is.min.js"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=window.scroll"></script>
+    <script src="assets/js/theme.js"></script>
+
+    <!-- Meta Pixel Code -->
+    <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '1556559851381406');
+      fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+      src="https://www.facebook.com/tr?id=1556559851381406&ev=PageView&noscript=1"
+    /></noscript>
+    <!-- End Meta Pixel Code -->
+
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,200;1,300;1,400&amp;display=swap" rel="stylesheet">
+  </body>
+
+</html>

--- a/contributions.html
+++ b/contributions.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en-US" dir="ltr">
+
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+
+    <!-- ===============================================-->
+    <!--    Document Title-->
+    <!-- ===============================================-->
+    <title>Contributions | PH Government Online</title>
+
+
+    <!-- ===============================================-->
+    <!--    Favicons-->
+    <!-- ===============================================-->
+    <link rel="apple-touch-icon" sizes="180x180" href="assets/img/favicons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/img/favicons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="assets/img/favicons/favicon-16x16.png">
+    <link rel="shortcut icon" type="image/x-icon" href="assets/img/favicons/favicon.ico">
+    <link rel="manifest" href="assets/img/favicons/manifest.json">
+    <meta name="msapplication-TileImage" content="assets/img/favicons/mstile-150x150.png">
+    <meta name="theme-color" content="#ffffff">
+
+
+    <!-- ===============================================-->
+    <!--    Stylesheets-->
+    <!-- ===============================================-->
+    <link href="assets/css/theme.css" rel="stylesheet" />
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VSNFJDN5JM"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-VSNFJDN5JM');
+    </script>
+  </head>
+
+
+  <body>
+
+    <!-- ===============================================-->
+    <!--    Main Content-->
+    <!-- ===============================================-->
+    <main class="main" id="top">
+      <nav class="navbar navbar-expand-lg navbar-light py-3 backdrop" data-navbar-on-scroll="data-navbar-on-scroll">
+        <div class="container"><a class="navbar-brand  mx-auto fw-bolder fs-2 fst-italic" href="index.html">
+           <img src="assets/img/logo.png" width="50px" alt="PH Online Services logo">
+            <span class="text-info">PH ONLINE</span>
+            <span class="text-warning">SERVICES</span>
+          </a>
+        </div>
+
+      </nav>
+
+      <section class="py-5 pt-0">
+        <div class="bg-holder d-none d-sm-block" style="background-image:url(assets/img/illustrations/category-bg.png);background-position:right top;background-size:200px 320px;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container mt-3">
+          <div class="row justify-content-center">
+            <div class="col-md-9 col-lg-8 text-center mb-3">
+              <h1 class="fw-bold fs-3 fs-lg-5 lh-sm mb-3">Contributions</h1>
+              <p class="mb-4">Handle SSS, Pag-IBIG and PhilHealth member registrations, employer reporting and contribution management in one place.</p>
+              <a class="btn btn-outline-primary btn-sm" href="index.html#categorieslist">&larr; Back to all categories</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-5">
+        <div class="container">
+          <div class="main-list">
+            <div class="category mb-5">
+              <h4 class="mb-3">Benefits Registration</h4>
+              <div class="individual-service mb-2"> <a href="https://www.sss.gov.ph/sss/portlets/retirementestimator/retirementEstimator1.jsp" target="_blank" rel="noopener noreferrer">Calculate Possible Retirement Benefit with SSS</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.sss.gov.ph/" target="_blank" rel="noopener noreferrer">Register as SSS Member</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.sss.gov.ph/sss/DownloadContent?fileName=SSSForm_Unified_Registration_Form_Kasambahay.pdf" target="_blank" rel="noopener noreferrer">Register your Kasambahay (SSS Form)</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.pagibigfundservices.com/kasambahay/default.aspx" target="_blank" rel="noopener noreferrer">Register your Kasambahay to Pag-IBIG, SSS, and PhilHealth Online</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.pagibigfundservices.com/PubReg/Starter_Page.aspx" target="_blank" rel="noopener noreferrer">Register your Pag-IBIG Member's Information</a> </div>
+              <div class="individual-service mb-2"> <a href="https://eprs01.philhealth.gov.ph/" target="_blank" rel="noopener noreferrer">Report PhilHealth Premium Contributions of your Employees</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.sss.gov.ph/" target="_blank" rel="noopener noreferrer">Submit Loan Collection List for Employers</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.sss.gov.ph/sss/appmanager/pages.jsp?page=sicknessapplication" target="_blank" rel="noopener noreferrer">Submit Sickness Notification for Employers</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.pagibigfundservices.com/esrsemployer/default.aspx" target="_blank" rel="noopener noreferrer">Submit your Pag-IBIG Monthly Remittance (eSRS) Online</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.sss.gov.ph/" target="_blank" rel="noopener noreferrer">Update SSS Information</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Certificates</h4>
+              <div class="individual-service mb-2"> <a href="https://egsismo.gsis.gov.ph/eGSISMO/" target="_blank" rel="noopener noreferrer">View your GSIS Membership Record</a> </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-0 bg-primary-gradient">
+        <div class="bg-holder" style="background-image:url(assets/img/illustrations/footer-bg.png);background-position:center;background-size:cover;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container">
+
+          <div class="row flex-center">
+            <div class="col-auto my-4">
+              <ul class="list-unstyled list-inline">
+                <li class="list-inline-item me-3"><a class="text-decoration-none" href="https://www.facebook.com/yudipotech/">
+                    <svg class="bi bi-facebook" xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="#1F3A63" viewBox="0 0 16 16">
+                      <path d="M16 8.049c0-4.446-3.582-8.05-8-8.05C3.58 0-.002 3.603-.002 8.05c0 4.017 2.926 7.347 6.75 7.951v-5.625h-2.03V8.05H6.75V6.275c0-2.017 1.195-3.131 3.022-3.131.876 0 1.791.157 1.791.157v1.98h-1.009c-.993 0-1.303.621-1.303 1.258v1.51h2.218l-.354 2.326H9.25V16c3.824-.604 6.75-3.934 6.75-7.951z"></path>
+                    </svg></a></li>
+              </ul>
+            </div>
+          </div>
+          <div class="row justify-content-center">
+            <div class="col-auto mb-2">
+              <p class="mb-0 fs--1 text-white my-2 text-center">&copy; 2022 YUDIPO TECH
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <!-- ===============================================-->
+    <!--    End of Main Content-->
+    <!-- ===============================================-->
+
+
+
+
+    <!-- ===============================================-->
+    <!--    JavaScripts-->
+    <!-- ===============================================-->
+    <script src="vendors/@popperjs/popper.min.js"></script>
+    <script src="vendors/bootstrap/bootstrap.min.js"></script>
+    <script src="vendors/is/is.min.js"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=window.scroll"></script>
+    <script src="assets/js/theme.js"></script>
+
+    <!-- Meta Pixel Code -->
+    <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '1556559851381406');
+      fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+      src="https://www.facebook.com/tr?id=1556559851381406&ev=PageView&noscript=1"
+    /></noscript>
+    <!-- End Meta Pixel Code -->
+
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,200;1,300;1,400&amp;display=swap" rel="stylesheet">
+  </body>
+
+</html>

--- a/education.html
+++ b/education.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en-US" dir="ltr">
+
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+
+    <!-- ===============================================-->
+    <!--    Document Title-->
+    <!-- ===============================================-->
+    <title>Education Services | PH Government Online</title>
+
+
+    <!-- ===============================================-->
+    <!--    Favicons-->
+    <!-- ===============================================-->
+    <link rel="apple-touch-icon" sizes="180x180" href="assets/img/favicons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/img/favicons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="assets/img/favicons/favicon-16x16.png">
+    <link rel="shortcut icon" type="image/x-icon" href="assets/img/favicons/favicon.ico">
+    <link rel="manifest" href="assets/img/favicons/manifest.json">
+    <meta name="msapplication-TileImage" content="assets/img/favicons/mstile-150x150.png">
+    <meta name="theme-color" content="#ffffff">
+
+
+    <!-- ===============================================-->
+    <!--    Stylesheets-->
+    <!-- ===============================================-->
+    <link href="assets/css/theme.css" rel="stylesheet" />
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VSNFJDN5JM"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-VSNFJDN5JM');
+    </script>
+  </head>
+
+
+  <body>
+
+    <!-- ===============================================-->
+    <!--    Main Content-->
+    <!-- ===============================================-->
+    <main class="main" id="top">
+      <nav class="navbar navbar-expand-lg navbar-light py-3 backdrop" data-navbar-on-scroll="data-navbar-on-scroll">
+        <div class="container"><a class="navbar-brand  mx-auto fw-bolder fs-2 fst-italic" href="index.html">
+           <img src="assets/img/logo.png" width="50px" alt="PH Online Services logo">
+            <span class="text-info">PH ONLINE</span>
+            <span class="text-warning">SERVICES</span>
+          </a>
+        </div>
+
+      </nav>
+
+      <section class="py-5 pt-0">
+        <div class="bg-holder d-none d-sm-block" style="background-image:url(assets/img/illustrations/category-bg.png);background-position:right top;background-size:200px 320px;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container mt-3">
+          <div class="row justify-content-center">
+            <div class="col-md-9 col-lg-8 text-center mb-3">
+              <h1 class="fw-bold fs-3 fs-lg-5 lh-sm mb-3">Education Services</h1>
+              <p class="mb-4">Explore scholarship programs, online courses, professional development and research support for Filipino learners and educators.</p>
+              <a class="btn btn-outline-primary btn-sm" href="index.html#categorieslist">&larr; Back to all categories</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-5">
+        <div class="container">
+          <div class="main-list">
+            <div class="category mb-5">
+              <h4 class="mb-3">Financial Assistance</h4>
+              <div class="individual-service mb-2"> <a href="https://ched.gov.ph/stufaps/" target="_blank" rel="noopener noreferrer">Apply for CHED Financial Assistance</a> </div>
+              <div class="individual-service mb-2"> <a href="https://ovap.peac.org.ph/" target="_blank" rel="noopener noreferrer">Apply Online for SHS Voucher Program</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Online Certificate Courses</h4>
+              <div class="individual-service mb-2"> <a href="http://ciap.dti.gov.ph/content/e-learning" target="_blank" rel="noopener noreferrer">Access CIAP Online Courses</a> </div>
+              <div class="individual-service mb-2"> <a href="http://e-extension.gov.ph/elearning/" target="_blank" rel="noopener noreferrer">Apply for DA eLearning Certification</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.e-tesda.gov.ph/login/signup.php" target="_blank" rel="noopener noreferrer">Apply for TESDA Online Program</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Professionals</h4>
+              <div class="individual-service mb-2"> <a href="http://bspms.dost.gov.ph/" target="_blank" rel="noopener noreferrer">Apply to the Balik Scientist Program (BSP)</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Research and Proposal</h4>
+              <div class="individual-service mb-2"> <a href="http://www.projects.pchrd.dost.gov.ph/index.php/pms-home" target="_blank" rel="noopener noreferrer">Apply for PCHRD Research Grant</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Scholarships and Grants</h4>
+              <div class="individual-service mb-2"> <a href="https://ched.gov.ph/stufaps/" target="_blank" rel="noopener noreferrer">Apply for CHED Foreign Scholarship and Training Programs</a> </div>
+              <div class="individual-service mb-2"> <a href="http://www.dost.gov.ph/products-and-services/s-t-scholarships" target="_blank" rel="noopener noreferrer">Apply for DOST Scholarship Grants</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.tesda.gov.ph/Barangay/" target="_blank" rel="noopener noreferrer">Apply for TESDA Scholarship</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Training</h4>
+              <div class="individual-service mb-2"> <a href="https://dost.gov.ph/products-and-services/application-to-the-dost-jsps-joint-scientific-research-program" target="_blank" rel="noopener noreferrer">Apply to the DOST-JSPS Joint Scientific Research Program</a> </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-0 bg-primary-gradient">
+        <div class="bg-holder" style="background-image:url(assets/img/illustrations/footer-bg.png);background-position:center;background-size:cover;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container">
+
+          <div class="row flex-center">
+            <div class="col-auto my-4">
+              <ul class="list-unstyled list-inline">
+                <li class="list-inline-item me-3"><a class="text-decoration-none" href="https://www.facebook.com/yudipotech/">
+                    <svg class="bi bi-facebook" xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="#1F3A63" viewBox="0 0 16 16">
+                      <path d="M16 8.049c0-4.446-3.582-8.05-8-8.05C3.58 0-.002 3.603-.002 8.05c0 4.017 2.926 7.347 6.75 7.951v-5.625h-2.03V8.05H6.75V6.275c0-2.017 1.195-3.131 3.022-3.131.876 0 1.791.157 1.791.157v1.98h-1.009c-.993 0-1.303.621-1.303 1.258v1.51h2.218l-.354 2.326H9.25V16c3.824-.604 6.75-3.934 6.75-7.951z"></path>
+                    </svg></a></li>
+              </ul>
+            </div>
+          </div>
+          <div class="row justify-content-center">
+            <div class="col-auto mb-2">
+              <p class="mb-0 fs--1 text-white my-2 text-center">&copy; 2022 YUDIPO TECH
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <!-- ===============================================-->
+    <!--    End of Main Content-->
+    <!-- ===============================================-->
+
+
+
+
+    <!-- ===============================================-->
+    <!--    JavaScripts-->
+    <!-- ===============================================-->
+    <script src="vendors/@popperjs/popper.min.js"></script>
+    <script src="vendors/bootstrap/bootstrap.min.js"></script>
+    <script src="vendors/is/is.min.js"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=window.scroll"></script>
+    <script src="assets/js/theme.js"></script>
+
+    <!-- Meta Pixel Code -->
+    <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '1556559851381406');
+      fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+      src="https://www.facebook.com/tr?id=1556559851381406&ev=PageView&noscript=1"
+    /></noscript>
+    <!-- End Meta Pixel Code -->
+
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,200;1,300;1,400&amp;display=swap" rel="stylesheet">
+  </body>
+
+</html>

--- a/employment.html
+++ b/employment.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en-US" dir="ltr">
+
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+
+    <!-- ===============================================-->
+    <!--    Document Title-->
+    <!-- ===============================================-->
+    <title>Employment Services | PH Government Online</title>
+
+
+    <!-- ===============================================-->
+    <!--    Favicons-->
+    <!-- ===============================================-->
+    <link rel="apple-touch-icon" sizes="180x180" href="assets/img/favicons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/img/favicons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="assets/img/favicons/favicon-16x16.png">
+    <link rel="shortcut icon" type="image/x-icon" href="assets/img/favicons/favicon.ico">
+    <link rel="manifest" href="assets/img/favicons/manifest.json">
+    <meta name="msapplication-TileImage" content="assets/img/favicons/mstile-150x150.png">
+    <meta name="theme-color" content="#ffffff">
+
+
+    <!-- ===============================================-->
+    <!--    Stylesheets-->
+    <!-- ===============================================-->
+    <link href="assets/css/theme.css" rel="stylesheet" />
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VSNFJDN5JM"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-VSNFJDN5JM');
+    </script>
+  </head>
+
+
+  <body>
+
+    <!-- ===============================================-->
+    <!--    Main Content-->
+    <!-- ===============================================-->
+    <main class="main" id="top">
+      <nav class="navbar navbar-expand-lg navbar-light py-3 backdrop" data-navbar-on-scroll="data-navbar-on-scroll">
+        <div class="container"><a class="navbar-brand  mx-auto fw-bolder fs-2 fst-italic" href="index.html">
+           <img src="assets/img/logo.png" width="50px" alt="PH Online Services logo">
+            <span class="text-info">PH ONLINE</span>
+            <span class="text-warning">SERVICES</span>
+          </a>
+        </div>
+
+      </nav>
+
+      <section class="py-5 pt-0">
+        <div class="bg-holder d-none d-sm-block" style="background-image:url(assets/img/illustrations/category-bg.png);background-position:right top;background-size:200px 320px;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container mt-3">
+          <div class="row justify-content-center">
+            <div class="col-md-9 col-lg-8 text-center mb-3">
+              <h1 class="fw-bold fs-3 fs-lg-5 lh-sm mb-3">Employment Services</h1>
+              <p class="mb-4">Discover job opportunities, professional licensing resources and programs that support Filipino workers locally and overseas.</p>
+              <a class="btn btn-outline-primary btn-sm" href="index.html#categorieslist">&larr; Back to all categories</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-5">
+        <div class="container">
+          <div class="main-list">
+            <div class="category mb-5">
+              <h4 class="mb-3">Job Openings</h4>
+              <div class="individual-service mb-2"> <a href="http://csc.gov.ph/career/" target="_blank" rel="noopener noreferrer">Apply for Government Employment Opportunities</a> </div>
+              <div class="individual-service mb-2"> <a href="http://www.poea.gov.ph/cgi-bin/JobVacancies/jobsMenu.asp" target="_blank" rel="noopener noreferrer">View and Verify Agency's Job Orders Abroad</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Professionals</h4>
+              <div class="individual-service mb-2"> <a href="http://cpdas.prc.gov.ph/public/appprovider.aspx" target="_blank" rel="noopener noreferrer">Apply as Continuing Professional Development (CPD) Provider</a> </div>
+              <div class="individual-service mb-2"> <a href="https://comex.csc.gov.ph/user/registration/form?execution=e1s1" target="_blank" rel="noopener noreferrer">Apply for Computerized CSC Examination</a> </div>
+              <div class="individual-service mb-2"> <a href="http://csc.gov.ph/2014-02-27-07-38-08/2014-02-27-07-39-33.html" target="_blank" rel="noopener noreferrer">Apply for CSC Authentication of Certificate of Eligibility</a> </div>
+              <div class="individual-service mb-2"> <a href="http://csc.gov.ph/2014-02-27-07-36-50/2014-02-27-07-37-12.html" target="_blank" rel="noopener noreferrer">Apply for CSC Examination (Paper and Pencil Test)</a> </div>
+              <div class="individual-service mb-2"> <a href="http://csc.gov.ph/2014-02-27-07-38-08/2014-02-27-07-40-14.html" target="_blank" rel="noopener noreferrer">Apply for CSC Grant of Eligibility under Special Laws and CSC Issuances</a> </div>
+              <div class="individual-service mb-2"> <a href="http://csc.gov.ph/2014-02-27-07-38-08/2014-02-27-07-39-33.html" target="_blank" rel="noopener noreferrer">Claim CSC Certificate of Eligibility</a> </div>
+              <div class="individual-service mb-2"> <a href="http://www.prc.gov.ph/uploaded/documents/rd%20oath%20form.pdf" target="_blank" rel="noopener noreferrer">Download PRC Oath Form</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.prc.gov.ph/room-assignment" target="_blank" rel="noopener noreferrer">Find Examination Location and Room Assignment (PRC Licensure Examination)</a> </div>
+              <div class="individual-service mb-2"> <a href="http://erpo.csc.gov.ph/ocsergs/" target="_blank" rel="noopener noreferrer">Generate your Career Service Examination Result Online (for 2018 onwards)</a> </div>
+              <div class="individual-service mb-2"> <a href="https://online.prc.gov.ph/" target="_blank" rel="noopener noreferrer">Renew PRC ID</a> </div>
+              <div class="individual-service mb-2"> <a href="http://cpdas.prc.gov.ph/public/index.aspx" target="_blank" rel="noopener noreferrer">Search for Continuing Professional Development (CPD) Programs</a> </div>
+              <div class="individual-service mb-2"> <a href="http://online.prc.gov.ph/Verification" target="_blank" rel="noopener noreferrer">Verify PRC Exam Rating</a> </div>
+              <div class="individual-service mb-2"> <a href="http://online.prc.gov.ph/Verification" target="_blank" rel="noopener noreferrer">Verify PRC License</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.prc.gov.ph/examination-result" target="_blank" rel="noopener noreferrer">View PRC Exam Results</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Salary Loans</h4>
+              <div class="individual-service mb-2"> <a href="https://www.dbp.ph/personal-banking/salary-loan/ec-credit-salary-loan/" target="_blank" rel="noopener noreferrer">Apply for EC Credit Salary Loan</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Union Association</h4>
+              <div class="individual-service mb-2"> <a href="https://blr-ours.dole.gov.ph/" target="_blank" rel="noopener noreferrer">Register Enterprised-based Union</a> </div>
+              <div class="individual-service mb-2"> <a href="https://blr.dole.gov.ph/2019/02/12/ouvp/" target="_blank" rel="noopener noreferrer">Verify Enterprised-based Union</a> </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-0 bg-primary-gradient">
+        <div class="bg-holder" style="background-image:url(assets/img/illustrations/footer-bg.png);background-position:center;background-size:cover;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container">
+
+          <div class="row flex-center">
+            <div class="col-auto my-4">
+              <ul class="list-unstyled list-inline">
+                <li class="list-inline-item me-3"><a class="text-decoration-none" href="https://www.facebook.com/yudipotech/">
+                    <svg class="bi bi-facebook" xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="#1F3A63" viewBox="0 0 16 16">
+                      <path d="M16 8.049c0-4.446-3.582-8.05-8-8.05C3.58 0-.002 3.603-.002 8.05c0 4.017 2.926 7.347 6.75 7.951v-5.625h-2.03V8.05H6.75V6.275c0-2.017 1.195-3.131 3.022-3.131.876 0 1.791.157 1.791.157v1.98h-1.009c-.993 0-1.303.621-1.303 1.258v1.51h2.218l-.354 2.326H9.25V16c3.824-.604 6.75-3.934 6.75-7.951z"></path>
+                    </svg></a></li>
+              </ul>
+            </div>
+          </div>
+          <div class="row justify-content-center">
+            <div class="col-auto mb-2">
+              <p class="mb-0 fs--1 text-white my-2 text-center">&copy; 2022 YUDIPO TECH
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <!-- ===============================================-->
+    <!--    End of Main Content-->
+    <!-- ===============================================-->
+
+
+
+
+    <!-- ===============================================-->
+    <!--    JavaScripts-->
+    <!-- ===============================================-->
+    <script src="vendors/@popperjs/popper.min.js"></script>
+    <script src="vendors/bootstrap/bootstrap.min.js"></script>
+    <script src="vendors/is/is.min.js"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=window.scroll"></script>
+    <script src="assets/js/theme.js"></script>
+
+    <!-- Meta Pixel Code -->
+    <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '1556559851381406');
+      fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+      src="https://www.facebook.com/tr?id=1556559851381406&ev=PageView&noscript=1"
+    /></noscript>
+    <!-- End Meta Pixel Code -->
+
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,200;1,300;1,400&amp;display=swap" rel="stylesheet">
+  </body>
+
+</html>

--- a/health.html
+++ b/health.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en-US" dir="ltr">
+
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+
+    <!-- ===============================================-->
+    <!--    Document Title-->
+    <!-- ===============================================-->
+    <title>Health &amp; Emergency Services | PH Government Online</title>
+
+
+    <!-- ===============================================-->
+    <!--    Favicons-->
+    <!-- ===============================================-->
+    <link rel="apple-touch-icon" sizes="180x180" href="assets/img/favicons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/img/favicons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="assets/img/favicons/favicon-16x16.png">
+    <link rel="shortcut icon" type="image/x-icon" href="assets/img/favicons/favicon.ico">
+    <link rel="manifest" href="assets/img/favicons/manifest.json">
+    <meta name="msapplication-TileImage" content="assets/img/favicons/mstile-150x150.png">
+    <meta name="theme-color" content="#ffffff">
+
+
+    <!-- ===============================================-->
+    <!--    Stylesheets-->
+    <!-- ===============================================-->
+    <link href="assets/css/theme.css" rel="stylesheet" />
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VSNFJDN5JM"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-VSNFJDN5JM');
+    </script>
+  </head>
+
+
+  <body>
+
+    <!-- ===============================================-->
+    <!--    Main Content-->
+    <!-- ===============================================-->
+    <main class="main" id="top">
+      <nav class="navbar navbar-expand-lg navbar-light py-3 backdrop" data-navbar-on-scroll="data-navbar-on-scroll">
+        <div class="container"><a class="navbar-brand  mx-auto fw-bolder fs-2 fst-italic" href="index.html">
+           <img src="assets/img/logo.png" width="50px" alt="PH Online Services logo">
+            <span class="text-info">PH ONLINE</span>
+            <span class="text-warning">SERVICES</span>
+          </a>
+        </div>
+
+      </nav>
+
+      <section class="py-5 pt-0">
+        <div class="bg-holder d-none d-sm-block" style="background-image:url(assets/img/illustrations/category-bg.png);background-position:right top;background-size:200px 320px;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container mt-3">
+          <div class="row justify-content-center">
+            <div class="col-md-9 col-lg-8 text-center mb-3">
+              <h1 class="fw-bold fs-3 fs-lg-5 lh-sm mb-3">Health &amp; Emergency Services</h1>
+              <p class="mb-4">Access hazard bulletins, situational reports and weather tools that support disaster response and community health safety.</p>
+              <a class="btn btn-outline-primary btn-sm" href="index.html#categorieslist">&larr; Back to all categories</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-5">
+        <div class="container">
+          <div class="main-list">
+            <div class="category mb-5">
+              <h4 class="mb-3">Disaster-prone Areas</h4>
+              <div class="individual-service mb-2"> <a href="https://www.phivolcs.dost.gov.ph/" target="_blank" rel="noopener noreferrer">Check Volcanic Eruptions, Earthquakes, Tsunami and other related Geotectonic Phenomena</a> </div>
+              <div class="individual-service mb-2"> <a href="https://dromic.dswd.gov.ph/" target="_blank" rel="noopener noreferrer">Check DSWD Preparedness Response Online</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.phivolcs.dost.gov.ph/index.php/earthquake/earthquake-information3" target="_blank" rel="noopener noreferrer">Check Earthquake Information</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.phivolcs.dost.gov.ph/index.php/tsunami/tsunami-advisory-and-warning3" target="_blank" rel="noopener noreferrer">Check Tsunami Advisory and Warning</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.phivolcs.dost.gov.ph/index.php/volcano-hazard/volcano-bulletins3" target="_blank" rel="noopener noreferrer">Check Volcano Bulletins</a> </div>
+              <div class="individual-service mb-2"> <a href="https://hazardhunter.georisk.gov.ph/" target="_blank" rel="noopener noreferrer">Generate Initial Hazard Assessments in your Selected Location for Seismic, Volcanic, and Hydro-meteorological Hazards</a> </div>
+              <div class="individual-service mb-2"> <a href="https://geoanalytics.georisk.gov.ph/" target="_blank" rel="noopener noreferrer">Generate Summaries of Hazards and Risk Assessment and Perform Analysis and Visualization of Exposure and Elements at Risk to Natural Hazards</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Weather</h4>
+              <div class="individual-service mb-2"> <a href="https://philsensors.asti.dost.gov.ph/" target="_blank" rel="noopener noreferrer">Access Weather Data via PHILSENSORS</a> </div>
+              <div class="individual-service mb-2"> <a href="https://noah.up.edu.ph/#/" target="_blank" rel="noopener noreferrer">View Real-time Information on Hazards via Project NOAH</a> </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-0 bg-primary-gradient">
+        <div class="bg-holder" style="background-image:url(assets/img/illustrations/footer-bg.png);background-position:center;background-size:cover;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container">
+
+          <div class="row flex-center">
+            <div class="col-auto my-4">
+              <ul class="list-unstyled list-inline">
+                <li class="list-inline-item me-3"><a class="text-decoration-none" href="https://www.facebook.com/yudipotech/">
+                    <svg class="bi bi-facebook" xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="#1F3A63" viewBox="0 0 16 16">
+                      <path d="M16 8.049c0-4.446-3.582-8.05-8-8.05C3.58 0-.002 3.603-.002 8.05c0 4.017 2.926 7.347 6.75 7.951v-5.625h-2.03V8.05H6.75V6.275c0-2.017 1.195-3.131 3.022-3.131.876 0 1.791.157 1.791.157v1.98h-1.009c-.993 0-1.303.621-1.303 1.258v1.51h2.218l-.354 2.326H9.25V16c3.824-.604 6.75-3.934 6.75-7.951z"></path>
+                    </svg></a></li>
+              </ul>
+            </div>
+          </div>
+          <div class="row justify-content-center">
+            <div class="col-auto mb-2">
+              <p class="mb-0 fs--1 text-white my-2 text-center">&copy; 2022 YUDIPO TECH
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <!-- ===============================================-->
+    <!--    End of Main Content-->
+    <!-- ===============================================-->
+
+
+
+
+    <!-- ===============================================-->
+    <!--    JavaScripts-->
+    <!-- ===============================================-->
+    <script src="vendors/@popperjs/popper.min.js"></script>
+    <script src="vendors/bootstrap/bootstrap.min.js"></script>
+    <script src="vendors/is/is.min.js"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=window.scroll"></script>
+    <script src="assets/js/theme.js"></script>
+
+    <!-- Meta Pixel Code -->
+    <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '1556559851381406');
+      fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+      src="https://www.facebook.com/tr?id=1556559851381406&ev=PageView&noscript=1"
+    /></noscript>
+    <!-- End Meta Pixel Code -->
+
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,200;1,300;1,400&amp;display=swap" rel="stylesheet">
+  </body>
+
+</html>

--- a/housing.html
+++ b/housing.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en-US" dir="ltr">
+
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+
+    <!-- ===============================================-->
+    <!--    Document Title-->
+    <!-- ===============================================-->
+    <title>Housing Services | PH Government Online</title>
+
+
+    <!-- ===============================================-->
+    <!--    Favicons-->
+    <!-- ===============================================-->
+    <link rel="apple-touch-icon" sizes="180x180" href="assets/img/favicons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/img/favicons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="assets/img/favicons/favicon-16x16.png">
+    <link rel="shortcut icon" type="image/x-icon" href="assets/img/favicons/favicon.ico">
+    <link rel="manifest" href="assets/img/favicons/manifest.json">
+    <meta name="msapplication-TileImage" content="assets/img/favicons/mstile-150x150.png">
+    <meta name="theme-color" content="#ffffff">
+
+
+    <!-- ===============================================-->
+    <!--    Stylesheets-->
+    <!-- ===============================================-->
+    <link href="assets/css/theme.css" rel="stylesheet" />
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VSNFJDN5JM"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-VSNFJDN5JM');
+    </script>
+  </head>
+
+
+  <body>
+
+    <!-- ===============================================-->
+    <!--    Main Content-->
+    <!-- ===============================================-->
+    <main class="main" id="top">
+      <nav class="navbar navbar-expand-lg navbar-light py-3 backdrop" data-navbar-on-scroll="data-navbar-on-scroll">
+        <div class="container"><a class="navbar-brand  mx-auto fw-bolder fs-2 fst-italic" href="index.html">
+           <img src="assets/img/logo.png" width="50px" alt="PH Online Services logo">
+            <span class="text-info">PH ONLINE</span>
+            <span class="text-warning">SERVICES</span>
+          </a>
+        </div>
+
+      </nav>
+
+      <section class="py-5 pt-0">
+        <div class="bg-holder d-none d-sm-block" style="background-image:url(assets/img/illustrations/category-bg.png);background-position:right top;background-size:200px 320px;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container mt-3">
+          <div class="row justify-content-center">
+            <div class="col-md-9 col-lg-8 text-center mb-3">
+              <h1 class="fw-bold fs-3 fs-lg-5 lh-sm mb-3">Housing Services</h1>
+              <p class="mb-4">Apply for Pag-IBIG housing support, manage payments and find government resources for property ownership.</p>
+              <a class="btn btn-outline-primary btn-sm" href="index.html#categorieslist">&larr; Back to all categories</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-5">
+        <div class="container">
+          <div class="main-list">
+            <div class="category mb-5">
+              <h4 class="mb-3">Housing Loans</h4>
+              <div class="individual-service mb-2"> <a href="https://www.pagibigfundservices.com/repricing/" target="_blank" rel="noopener noreferrer">Apply for Pag-IBIG Conversion to Full Risk Based-Pricing (Re-Pricing)</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.pagibigfundservices.com/HousingLoan/Apply/Default.aspx" target="_blank" rel="noopener noreferrer">Apply for Pag-IBIG Housing Loan</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.pagibigfundservices.com/HLDeveloper/Account/Login.aspx" target="_blank" rel="noopener noreferrer">Apply for Pag-IBIG Housing Loan on Behalf of Prospective Borrowers</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.pagibigfundservices.com/OnlineHLVerification/" target="_blank" rel="noopener noreferrer">Check Pag-IBIG Housing Loan Payments</a> </div>
+              <div class="individual-service mb-2"> <a href="https://nha.gov.ph/programs/" target="_blank" rel="noopener noreferrer">Look for Different Government Housing Programs</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.pagibigfundservices.com/virtualpagibig/OPF.aspx?PT=CL" target="_blank" rel="noopener noreferrer">Pay Pag-IBIG Calamity Loan Online</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.pagibigfundservices.com/virtualpagibig/OPF.aspx?PT=HL" target="_blank" rel="noopener noreferrer">Pay Pag-IBIG Housing Loan Online</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.pagibigfundservices.com/virtualpagibig/OPF.aspx?PT=HF" target="_blank" rel="noopener noreferrer">Pay Pag-IBIG Housing Loan Processing Fee Online</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.pagibigfundservices.com/virtualpagibig/OPF.aspx?PT=M2" target="_blank" rel="noopener noreferrer">Pay Pag-IBIG MP2 Savings (Voluntary Savings) Online</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.pagibigfundservices.com/virtualpagibig/OPF.aspx?PT=ST" target="_blank" rel="noopener noreferrer">Pay Pag-IBIG Multi-Purpose Loan Online</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.pagibigfundservices.com/virtualpagibig/OPF.aspx?PT=MC" target="_blank" rel="noopener noreferrer">Pay Pag-IBIG Regular Savings (Mandatory Contribution) Online</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Land Titles</h4>
+              <div class="individual-service mb-2"> <a href="https://eserbisyo.lra.gov.ph/" target="_blank" rel="noopener noreferrer">Apply for Land Titles</a> </div>
+              <div class="individual-service mb-2"> <a href="http://www.hgc.gov.ph/compute.html" target="_blank" rel="noopener noreferrer">Compute Monthly Amortization</a> </div>
+              <div class="individual-service mb-2"> <a href="https://dhsud.gov.ph/list-of-brokers-salespersons/" target="_blank" rel="noopener noreferrer">View List of Real Estate Brokers/Salespersons</a> </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-0 bg-primary-gradient">
+        <div class="bg-holder" style="background-image:url(assets/img/illustrations/footer-bg.png);background-position:center;background-size:cover;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container">
+
+          <div class="row flex-center">
+            <div class="col-auto my-4">
+              <ul class="list-unstyled list-inline">
+                <li class="list-inline-item me-3"><a class="text-decoration-none" href="https://www.facebook.com/yudipotech/">
+                    <svg class="bi bi-facebook" xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="#1F3A63" viewBox="0 0 16 16">
+                      <path d="M16 8.049c0-4.446-3.582-8.05-8-8.05C3.58 0-.002 3.603-.002 8.05c0 4.017 2.926 7.347 6.75 7.951v-5.625h-2.03V8.05H6.75V6.275c0-2.017 1.195-3.131 3.022-3.131.876 0 1.791.157 1.791.157v1.98h-1.009c-.993 0-1.303.621-1.303 1.258v1.51h2.218l-.354 2.326H9.25V16c3.824-.604 6.75-3.934 6.75-7.951z"></path>
+                    </svg></a></li>
+              </ul>
+            </div>
+          </div>
+          <div class="row justify-content-center">
+            <div class="col-auto mb-2">
+              <p class="mb-0 fs--1 text-white my-2 text-center">&copy; 2022 YUDIPO TECH
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <!-- ===============================================-->
+    <!--    End of Main Content-->
+    <!-- ===============================================-->
+
+
+
+
+    <!-- ===============================================-->
+    <!--    JavaScripts-->
+    <!-- ===============================================-->
+    <script src="vendors/@popperjs/popper.min.js"></script>
+    <script src="vendors/bootstrap/bootstrap.min.js"></script>
+    <script src="vendors/is/is.min.js"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=window.scroll"></script>
+    <script src="assets/js/theme.js"></script>
+
+    <!-- Meta Pixel Code -->
+    <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '1556559851381406');
+      fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+      src="https://www.facebook.com/tr?id=1556559851381406&ev=PageView&noscript=1"
+    /></noscript>
+    <!-- End Meta Pixel Code -->
+
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,200;1,300;1,400&amp;display=swap" rel="stylesheet">
+  </body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
     <!-- ===============================================-->
     <main class="main" id="top">
       <nav class="navbar navbar-expand-lg navbar-light py-3 backdrop" data-navbar-on-scroll="data-navbar-on-scroll">
-        <div class="container"><a class="navbar-brand  mx-auto fw-bolder fs-2 fst-italic" href="#">
+        <div class="container"><a class="navbar-brand  mx-auto fw-bolder fs-2 fst-italic" href="index.html">
            <img src="assets/img/logo.png" width="50px">
             <span class="text-info">PH ONLINE</span>
             <span class="text-warning">SERVICES</span>
@@ -74,7 +74,7 @@
               <div class="row">
                 <div class="col-sm-6 col-lg-4 pb-lg-6 px-lg-4 pb-4">
                   <div class="card py-4 shadow-sm h-100 hover-top">
-                    <a href="https://smart.com.ph/simreg">
+                    <a href="https://simreg.smart.com.ph/">
                     <div class="text-center"> <img src="assets/img/logos/smartlogo.png"  class="img-fluid" height="120" alt="" />
                       <div class="card-body px-2">
                         <h6 class="fw-bold fs-1 heading-color">Smart/TNT/Sun</h6>
@@ -98,8 +98,8 @@
                 </div>
                 <div class="col-sm-6 col-lg-4 pb-lg-6 px-lg-4 pb-4">
                   <div class="card py-4 shadow-sm h-100 hover-top">
-                    <a href="https://smart.com.ph/simreg">
-                    <div class="text-center"> <img src="assets/img/logos/ditologo.jpg"  class="img-fluid" height="120" alt="" />
+                    <a href="https://dito.ph/register">
+                    <div class="text-center"> <img src="assets/img/logos/ditologo.jpg"  class="img-fluid" height="120" alt="DITO logo" />
                       <div class="card-body px-2">
                         <h6 class="fw-bold fs-1 heading-color">DITO </h6>
                         <p class="mb-0 card-text">Register Your Sim Card</p>
@@ -170,7 +170,7 @@
                 </div>
                 <div class="col-sm-6 col-lg-4 pb-lg-6 px-lg-4 pb-4">
                   <div class="card py-4 shadow-sm h-100 hover-top">
-                    <a href="https://www.sss.gov.ph/sss/">
+                    <a href="https://www.sss.gov.ph/">
                     <div class="text-center"> <img src="assets/img/logos/sss.png" class="img-fluid" height="120" alt="" />
                       <div class="card-body px-2">
                         <h6 class="fw-bold fs-1 heading-color">SSS</h6>
@@ -182,8 +182,8 @@
                 </div>
                 <div class="col-sm-6 col-lg-4 pb-lg-6 px-lg-4 pb-4">
                   <div class="card py-4 shadow-sm h-100 hover-top">
-                    <a href="">
-                    <div class="text-center"> <img src="assets/img/logos/philpost.jpg" class="img-fluid" height="120" alt="https://phlpost.gov.ph/" />
+                    <a href="https://www.phlpost.gov.ph/services/postal-id/">
+                    <div class="text-center"> <img src="assets/img/logos/philpost.jpg" class="img-fluid" height="120" alt="PhilPost logo" />
                       <div class="card-body px-2">
                         <h6 class="fw-bold fs-1 heading-color">POSTAL ID</h6>
                         <p class="mb-0 card-text">PhilPost Postal ID</p>
@@ -240,892 +240,145 @@
           <div class="row justify-content-center">
             <div class="col-md-9 col-lg-6 text-center mb-3">
               <h5 class="fw-bold fs-3 fs-lg-5 lh-sm mb-3" id="categorieslist">Browse by Category</h5>
-              <p class="mb-5">Choose from the list of categories</p>
+              <p class="mb-5">Choose a category to open its dedicated services page.</p>
             </div>
           </div>
-          <div class="accordion" id="accordionExample">
-            <div class="accordion-item">
-              <h2 class="accordion-header" id="headingOne">
-                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseCerts" aria-expanded="true" aria-controls="collapseCerts">
-                  Certificates and IDs
-                </button>
-              </h2>
-              <div class="accordion-collapse collapse" id="collapseCerts" data-bs-parent="#accordionExample">
-                <div class="card card-body">
-
-                    <div class="main-list">
-                       <div id="section1" class="category">
-                          <h4>Certificates</h4>
-                          <div class="individual-service mb-2"> <a href="http://www.dost.gov.ph/products-and-services/accreditation-and-certification.html" target="_blank">Apply for DOST Accreditation and Certification</a> </div>
-                          <div class="individual-service mb-2"> <a href="https://sfu.dost.gov.ph" target="_blank">Avail Certification of Science and Technology-oriented Foundations</a> </div>
-                          <div class="individual-service mb-2"> <a href="https://psa.gov.ph/civilregistration/problems-and-solutions" target="_blank">Know How to Correct Errors in your Civil Registry Documents</a> </div>
-                          <div class="individual-service mb-2"> <a href="https://www.psaserbilis.com.ph/Default.aspx" target="_blank">Request a Birth Certificate via PSA Serbilis</a> </div>
-                          <div class="individual-service mb-2"> <a href="https://psahelpline.ph/" target="_blank">Request a Birth Certificate via PSAHelpline.ph</a> </div>
-                          <div class="individual-service mb-2"> <a href="https://www.psaserbilis.com.ph/Default.aspx" target="_blank">Request a Certificate of No Marriage Record (CENOMAR) via PSA Serbilis</a> </div>
-                          <div class="individual-service mb-2"> <a href="https://psahelpline.ph/" target="_blank">Request a Certificate of No Marriage Record (CENOMAR) via PSAHelpline.ph</a> </div>
-                          <div class="individual-service mb-2"> <a href="https://www.psaserbilis.com.ph/Default.aspx" target="_blank">Request a Death Certificate via PSA Serbilis</a> </div>
-                          <div class="individual-service mb-2"> <a href="https://psahelpline.ph/" target="_blank">Request a Death Certificate via PSAHelpline.ph</a> </div>
-                          <div class="individual-service mb-2"> <a href="https://www.psaserbilis.com.ph/Default.aspx" target="_blank">Request a Marriage Certificate via PSA Serbilis</a> </div>
-                          <div class="individual-service mb-2"> <a href="https://psahelpline.ph/" target="_blank">Request a Marriage Certificate via PSAHelpline.ph</a> </div>
-                       </div>
-                       <div id="section2" class="category">
-                          <h4>Clearances</h4>
-                          <div class="individual-service mb-2"> <a href="https://clearance.nbi.gov.ph/" target="_blank">Apply for NBI Multipurpose Clearance</a> </div>
-                          <div class="individual-service mb-2"> <a href="https://clearance.nbi.gov.ph/" target="_blank">Renew NBI Multipurpose Clearance</a> </div>
-                       </div>
-                       <div id="section3" class="category">
-                          <h4>ID</h4>
-                          <div class="individual-service mb-2"> <a href="https://owwa.gov.ph/?page_id=3821" target="_blank">Apply for OWWA OFW e-Card</a> </div>
-                          <div class="individual-service mb-2"> <a href="https://www.postalidph.com/how-to-apply.html" target="_blank">Get a Postal ID</a> </div>
-                          <div class="individual-service mb-2"> <a href="http://www.ncda.gov.ph/2009/07/apply-fo-pwd-id-card/" target="_blank">Get a PWD ID</a> </div>
-                          <div class="individual-service mb-2"> <a href="https://psa.gov.ph/sites/default/files/attachments/aodao/article/Q%20%26%20A_Solo%20Parent%27s%20Welfare%20Act%20and%20Parental%20Leave.pdf" target="_blank">Get a Solo Parent ID</a> </div>
-                          <div class="individual-service mb-2"> <a href="https://www.sss.gov.ph/sss/DownloadContent?fileName=SSSForms_UMID_Application.pdf" target="_blank">Get a UMID ID</a> </div>
-                          <div class="individual-service mb-2"> <a href="https://register.philsys.gov.ph/#/eng" target="_blank">Register to the Philippine Identification System (PhilSys) or National ID</a></div>
-                          <div class="individual-service mb-2">  <a href="http://ecard.owwa.gov.ph/applicationform/tracker.php" target="_blank">Track your OWWA OFW e-Card</a> </div>
-                       </div>
-                       <div id="section4" class="category">
-                          <h4>Voters</h4>
-                          <div class="individual-service mb-2"> <a href="https://comelec.gov.ph/?r=VoterRegistration/VoterVerification/precinct_finder" target="_blank">Verify Your Voter Status and Voting Precinct Location</a> </div>
-                       </div>
-                    </div>
-
-                </div>
-              </div>
-            </div>
-
-            <div class="accordion-item">
-              <h2 class="accordion-header" id="headingOne">
-                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseBusiness" aria-expanded="true" aria-controls="collapseBusiness">
-                  Business and Trade
-                </button>
-              </h2>
-              <div class="accordion-collapse collapse" id="collapseBusiness" data-bs-parent="#accordionExample">
-                  <div class="card card-body">
-
-                      <div class="main-list">
-                        <div id="section1" class="category">
-                          <h4>Business Copyright, Trademark and Patent</h4>
-                          <div class="individual-service mb-2">
-                            <a href="http://121.58.254.39:8080/sp-ui-tmefiling/wizard.htm?execution=e1s1" target="_blank">Apply for a Trademark Online</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://onlineservices.ipophil.gov.ph/eUMFile/" target="_blank">Apply for a Utility Model</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://onlineservices.ipophil.gov.ph/eIDFile/" target="_blank">File for IPOPHL Industrial Design</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://onlineservices.ipophil.gov.ph/eInventionFile/" target="_blank">Request for a Grant of a Philippine Patent</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="http://www.wipo.int/branddb/ph/en/" target="_blank">Search Trademark Information</a>
-                          </div>
-                        </div>
-                        <div id="section2" class="category">
-                          <h4>Business Registration, Certificates and Compliance</h4>
-                          <div class="individual-service mb-2">
-                            <a href="https://emb.gov.ph/issuance-of-certificate-of-conformity-coc-for-new-motor-vehicle-flowchart/" target="_blank">Apply for Certificate of Conformity</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://opms.emb.gov.ph/https" target="_blank">Apply for Environmental Laboratory Recognition</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="http://www.erc.gov.ph/ContentPage/203" target="_blank">Apply for ERC Certificate of Compliance</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://opms.emb.gov.ph/https" target="_blank">Apply for Importer and Importation Clearance for Recyclable Materials Containing Hazardous Substances</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://www.denr.gov.ph/index.php?id=352&amp;page=2&amp;sort=avl&amp;filter=creator&amp;filterID=43&amp;searchword=&amp;fromyear=&amp;frommonth=&amp;fromdate=&amp;toyear=&amp;tomonth=&amp;todate=&amp;dateval=" target="_blank">Apply for Non-CITES Wildlife Products - Import (Biodiversity Management)</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://opms.emb.gov.ph/https" target="_blank">Apply for Pre-Manufacture and Pre-Importation Notification Certificate</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://opms.emb.gov.ph/https" target="_blank">Apply for Priority Chemical List Compliance Certificate</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://opms.emb.gov.ph/https" target="_blank">Apply for Waste Water Discharge Permit</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://www.sec.gov.ph/online-services/registration-calculator/" target="_blank">Calculate Registration Fee of Stock Corporation</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://bnrs.dti.gov.ph/cancellation" target="_blank">Cancel your Application for Business Name Registration</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://cnconline.emb.gov.ph/projectchecker/ApplicationTracking.aspx?View=0" target="_blank">Check Status of CNC Application Online</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://ecconline.emb.gov.ph/live/" target="_blank">Check Status of ECC Application Online</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href=" https://www.sec.gov.ph/online-services/sec-company-registration-system/" target="_blank">Inquire Company Registration System (CRS) Status Online</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://bnrs.dti.gov.ph/registration" target="_blank">Register a Business Name </a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://bnrs.dti.gov.ph/pdf/download/application_form.pdf" target="_blank">Register a Sole Proprietorship Business</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://bnrs.dti.gov.ph/request-certification" target="_blank">Request for Business Name Certificate</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://bnrs.dti.gov.ph/renewal" target="_blank">Request for Renewal of Business Name</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="http://hlurb.gov.ph/wp-content/uploads/downloadable-forms/rem-forms/Zoning%20Certification.pdf" target="_blank">Request for Zoning Certification</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://secexpress.ph/" target="_blank">Request Securing Copies of Corporate and Partnership Documents</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://www.sec.gov.ph/online-services/sec-express-system/" target="_blank">Submit your Company’s General Information Sheet and/or Audited Financial Statements Online to SEC </a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://bnrs.dti.gov.ph/update-information" target="_blank">Update Information of your Application for a Business Name</a>
-                          </div>
-                        </div>
-                        <div id="section3" class="category">
-                          <h4>Complaints</h4>
-                          <div class="individual-service mb-2">
-                            <a href="http://investor.boiown.gov.ph/auth" target="_blank">Apply for Online Investment Assistance</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://www.dti.gov.ph/consumers/complaints" target="_blank">File Complaints on Consumer Affair Service</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="http://boi.gov.ph/boi-own/" target="_blank">Know more About Business or Investment-related Assistance</a>
-                          </div>
-                        </div>
-                        <div id="section4" class="category">
-                          <h4>Financial Assistance</h4>
-                          <div class="individual-service mb-2">
-                            <a href="https://www.dbp.ph/developmental-banking/" target="_blank">Apply for DBP ME and OBE Loan</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://www.dbp.ph/developmental-banking/" target="_blank">Apply for DBP mSME Loan </a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://www.dbp.ph/developmental-banking/" target="_blank">Apply for DBP RLM Loan</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://www.dbp.ph/developmental-banking/" target="_blank">Apply for DBP-Credit Surety Fund</a>
-                          </div>
-                        </div>
-                        <div id="section5" class="category">
-                          <h4>Import and Export</h4>
-                          <div class="individual-service mb-2">
-                            <a href="http://ears.peza.gov.ph/#/input" target="_blank">Apply for Registration as Ecozone Enterprise or Ecozone Developer</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://drive.google.com/file/d/1lcDlvI5BHJh-a81o-uSVmlQLAwgF4hPa/view" target="_blank">Apply Online for Advance Rulings on Tariff Classification and Tariff Classification Dispute Rulings</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="http://finder.tariffcommission.gov.ph/" target="_blank">Search for Tariff</a>
-                          </div>
-                        </div>
-                        <div id="section6" class="category">
-
-                        </div>
-                        <div id="section7" class="category">
-                          <h4>Price Control Monitoring</h4>
-                          <div class="individual-service mb-2">
-                            <a href="https://www.dti.gov.ph/konsyumer/e-presyo/" target="_blank">Check the Prevailing Prices of Basic Necessities and Prime Commodities (ePresyo)</a>
-                          </div>
-                          <div class="individual-service mb-2">
-                            <a href="https://nfa.gov.ph/buying-selling-price" target="_blank">Know the Buying and Selling Prices of Rice and Corn</a>
-                          </div>
-                        </div>
-                      </div>
-
+          <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-4">
+            <div class="col">
+              <div class="card h-100 shadow-sm hover-top text-center">
+                <a class="text-decoration-none" href="certificates-and-ids.html">
+                  <div class="card-body px-4 py-5">
+                    <h6 class="fw-bold fs-2 heading-color mb-3">Certificates &amp; IDs</h6>
+                    <p class="card-text text-secondary mb-4">Request civil registry documents, clearances, and government IDs.</p>
+                    <span class="fw-semibold text-primary">Explore services &rarr;</span>
                   </div>
+                </a>
               </div>
             </div>
-
-            <div class="accordion-item">
-              <h2 class="accordion-header" id="headingOne">
-                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseContributions" aria-expanded="true" aria-controls="collapseContributions">
-                  Contributions
-                </button>
-              </h2>
-              <div class="collapse" id="collapseContributions" data-bs-parent="#accordionExample">
-                <div class="card card-body">
-
-                  <div class="main-list">
-                    <div id="section1" class="category">
-                      <h4>Benefits Registration</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.sss.gov.ph/sss/portlets/retirementestimator/retirementEstimator1.jsp" target="_blank">Calculate Possible Retirement Benefit with SSS</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.sss.gov.ph/" target="_blank">Register as SSS Member</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.sss.gov.ph/sss/DownloadContent?fileName=SSSForm_Unified_Registration_Form_Kasambahay.pdf" target="_blank">Register your Kasambahay (SSS Form)</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.pagibigfundservices.com/kasambahay/default.aspx " target="_blank">Register your Kasambahay to Pag-IBIG, SSS, and PhilHealth Online</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.pagibigfundservices.com/PubReg/Starter_Page.aspx" target="_blank">Register your Pag-IBIG Member's Information</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://eprs01.philhealth.gov.ph/" target="_blank">Report PhilHealth Premium Contributions of your Employees</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.sss.gov.ph/" target="_blank">Submit Loan Collection List for Employers</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.sss.gov.ph/sss/appmanager/pages.jsp?page=sicknessapplication" target="_blank">Submit Sickness Notification for Employers</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.pagibigfundservices.com/esrsemployer/default.aspx" target="_blank">Submit your Pag-IBIG Monthly Remittance (eSRS) Online</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.sss.gov.ph/" target="_blank">Update SSS Information</a>
-                      </div>
-                    </div>
-                    <div id="section2" class="category">
-                      <h4>Certificates</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://egsismo.gsis.gov.ph/eGSISMO/" target="_blank">View your GSIS Membership Record</a>
-                      </div>
-                    </div>
+            <div class="col">
+              <div class="card h-100 shadow-sm hover-top text-center">
+                <a class="text-decoration-none" href="business-and-trade.html">
+                  <div class="card-body px-4 py-5">
+                    <h6 class="fw-bold fs-2 heading-color mb-3">Business &amp; Trade</h6>
+                    <p class="card-text text-secondary mb-4">Manage registrations, compliance, and investment assistance.</p>
+                    <span class="fw-semibold text-primary">Explore services &rarr;</span>
                   </div>
-
-                </div>
+                </a>
               </div>
             </div>
-
-            <div class="accordion-item">
-              <h2 class="accordion-header" id="headingOne">
-                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseWeather" aria-expanded="true" aria-controls="collapseWeather">
-                  Weather
-                </button>
-              </h2>
-              <div class="collapse" id="collapseWeather" data-bs-parent="#accordionExample">
-                <div class="card card-body">
-                  <div class="main-list">
-                    <div id="section1" class="category">
-                      <h4>Disaster-prone Areas</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.phivolcs.dost.gov.ph/" target="_blank">Check Volcanic Eruptions, Earthquakes, Tsunami and other related Geotectonic Phenomena</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://dromic.dswd.gov.ph/" target="_blank">Check DSWD Preparedness Response Online</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.phivolcs.dost.gov.ph/index.php/earthquake/earthquake-information3" target="_blank">Check Earthquake Information</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.phivolcs.dost.gov.ph/index.php/tsunami/tsunami-advisory-and-warning3" target="_blank">Check Tsunami Advisory and Warning</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.phivolcs.dost.gov.ph/index.php/volcano-hazard/volcano-bulletins3" target="_blank">Check Volcano Bulletins</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://hazardhunter.georisk.gov.ph/" target="_blank">Generate Initial Hazard Assessments in your Selected Location for Seismic, Volcanic, and Hydro-meteorological Hazards</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://geoanalytics.georisk.gov.ph/" target="_blank">Generate Summaries of Hazards and Risk Assessment and Perform Analysis and Visualization of Exposure and Elements at Risk to Natural Hazards</a>
-                      </div>
-                    </div>
-                    <div id="section2" class="category">
-                      <h4>Weather</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://philsensors.asti.dost.gov.ph/" target="_blank">Access Weather Data via PHILSENSORS</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://noah.up.edu.ph/#/" target="_blank">View Real-time Information on Hazards via Project NOAH</a>
-                      </div>
-                    </div>
+            <div class="col">
+              <div class="card h-100 shadow-sm hover-top text-center">
+                <a class="text-decoration-none" href="contributions.html">
+                  <div class="card-body px-4 py-5">
+                    <h6 class="fw-bold fs-2 heading-color mb-3">Contributions</h6>
+                    <p class="card-text text-secondary mb-4">Handle SSS, Pag-IBIG, PhilHealth, and GSIS contributions.</p>
+                    <span class="fw-semibold text-primary">Explore services &rarr;</span>
                   </div>
-                </div>
+                </a>
               </div>
             </div>
-
-            <div class="accordion-item">
-              <h2 class="accordion-header" id="headingOne">
-                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseEducation" aria-expanded="true" aria-controls="collapseEducation">
-                  Education
-                </button>
-              </h2>
-              <div class="collapse" id="collapseEducation" data-bs-parent="#accordionExample">
-                <div class="card card-body">
-                  <div class="main-list">
-                    <div id="section1" class="category">
-                      <h4>Financial Assistance</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://ched.gov.ph/stufaps/" target="_blank">Apply for CHED Financial Assistance</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://ovap.peac.org.ph/ " target="_blank">Apply Online for SHS Voucher Program for School Year 2019-2020</a>
-                      </div>
-                    </div>
-                    <div id="section2" class="category">
-                      <h4>Online Certificate Courses</h4>
-                      <div class="individual-service mb-2">
-                        <a href="http://ciap.dti.gov.ph/content/e-learning" target="_blank">Access CIAP Online Courses</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://e-extension.gov.ph/elearning/" target="_blank">Apply for DA eLearning Certification</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.e-tesda.gov.ph/login/signup.php" target="_blank">Apply for TESDA Online Program</a>
-                      </div>
-                    </div>
-                    <div id="section3" class="category">
-                      <h4>Professionals</h4>
-                      <div class="individual-service mb-2">
-                        <a href="http://bspms.dost.gov.ph/" target="_blank">Apply to the Balik Scientist Program (BSP)</a>
-                      </div>
-                    </div>
-                    <div id="section4" class="category">
-                      <h4>Research and Proposal</h4>
-                      <div class="individual-service mb-2">
-                        <a href="http://www.projects.pchrd.dost.gov.ph/index.php/pms-home " target="_blank">Apply for PCHRD Research Grant</a>
-                      </div>
-                    </div>
-                    <div id="section5" class="category">
-                      <h4>Scholarships and Grants</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://ched.gov.ph/stufaps/" target="_blank">Apply for CHED Foreign Scholarship and Training Programs</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://www.dost.gov.ph/products-and-services/s-t-scholarships" target="_blank">Apply for DOST Scholarship Grants</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.tesda.gov.ph/Barangay/" target="_blank">Apply for TESDA Scholarship</a>
-                      </div>
-                    </div>
-                    <div id="section6" class="category">
-                      <h4>Training</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://dost.gov.ph/products-and-services/application-to-the-dost-jsps-joint-scientific-research-program" target="_blank">Apply to the DOST-JSPS Joint Scientific Research Program </a>
-                      </div>
-                    </div>
+            <div class="col">
+              <div class="card h-100 shadow-sm hover-top text-center">
+                <a class="text-decoration-none" href="weather.html">
+                  <div class="card-body px-4 py-5">
+                    <h6 class="fw-bold fs-2 heading-color mb-3">Weather &amp; Disaster Preparedness</h6>
+                    <p class="card-text text-secondary mb-4">Stay informed with hazard maps, weather updates, and emergency resources.</p>
+                    <span class="fw-semibold text-primary">Explore services &rarr;</span>
                   </div>
-                </div>
+                </a>
               </div>
             </div>
-
-            <div class="accordion-item">
-              <h2 class="accordion-header" id="headingOne">
-                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseEmployment" aria-expanded="true" aria-controls="collapseEmployment">
-                  Employment
-                </button>
-              </h2>
-              <div class="collapse" id="collapseEmployment" data-bs-parent="#accordionExample">
-                <div class="card card-body">
-                  <div class="main-list">
-                    <div id="section1" class="category">
-                    </div>
-                    <div id="section2" class="category">
-                      <h4>Job Openings</h4>
-                      <div class="individual-service mb-2">
-                        <a href="http://csc.gov.ph/career/" target="_blank">Apply for Government Employment Opportunities</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://www.poea.gov.ph/cgi-bin/JobVacancies/jobsMenu.asp" target="_blank">View and Verify Agency's Job Orders Abroad</a>
-                      </div>
-                    </div>
-                    <!--<div id="section3" class="category">
-                      <h4>Overseas Jobs</h4>
-                      <div class="individual-service mb-2">
-                        <a href="http://www.poea.gov.ph/services/workers/registration_src.pdf " target="_blank">Apply as Seafarer</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://bmonline.ph/" target="_blank">Apply for Overseas Employment Certificate</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://www.poea.gov.ph/cgi-bin/agSearch.asp" target="_blank">Check Your Placement Agency Status</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://onlinelegalcounseling.1343actionline.ph/" target="_blank">File OFW Legal Assistance</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://balinkbayan.gov.ph/online-services.html" target="_blank">Look for Government Online Services for Filipinos Overseas</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://www.poea.gov.ph/services/workers/registration_LB.pdf" target="_blank">Register as Landbased Applicant for Overseas Employment</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://peos.poea.gov.ph/" target="_blank">Register for Overseas Pre-employment Seminar</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://uwianna.owwa.gov.ph/" target="_blank">Register to OWWA "Uwian Na" Program</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://onlineservices.poea.gov.ph/OnlineServices/POEAOnline.aspx" target="_blank">Register with POEA to Apply for Overseas Employment</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://ofwrecords.poea.gov.ph/" target="_blank">Set an Online Appointment to Request OFW Records</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://www.poea.gov.ph/cgi-bin/agList.asp?mode=act" target="_blank">Verify Validity of License or Holder of Recruitment Agencies</a>
-                      </div>
-                    </div>-->
-                    <div id="section4" class="category">
-                      <h4>Professionals</h4>
-                      <div class="individual-service mb-2">
-                        <a href="http://cpdas.prc.gov.ph/public/appprovider.aspx" target="_blank">Apply as Continuing Professional Development (CPD) Provider</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://comex.csc.gov.ph/user/registration/form?execution=e1s1" target="_blank">Apply for Computerized CSC Examination</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://csc.gov.ph/2014-02-27-07-38-08/2014-02-27-07-39-33.html" target="_blank">Apply for CSC Authentication of Certificate of Eligibility</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://csc.gov.ph/2014-02-27-07-36-50/2014-02-27-07-37-12.html" target="_blank">Apply for CSC Examination (Paper and Pencil Test)</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://csc.gov.ph/2014-02-27-07-38-08/2014-02-27-07-40-14.html" target="_blank">Apply for CSC Grant of Eligibility under Special Laws and CSC Issuances</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://csc.gov.ph/2014-02-27-07-38-08/2014-02-27-07-39-33.html" target="_blank">Claim CSC Certificate of Eligibility</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://www.prc.gov.ph/uploaded/documents/rd%20oath%20form.pdf" target="_blank">Download PRC Oath Form</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.prc.gov.ph/room-assignment" target="_blank">Find Examination Location and Room Assignment (PRC Licensure Examination)</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://erpo.csc.gov.ph/ocsergs/" target="_blank">Generate your Career Service Examination Result Online (for 2018 onwards)</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://online.prc.gov.ph/ " target="_blank">Renew PRC ID</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://cpdas.prc.gov.ph/public/index.aspx" target="_blank">Search for Continuing Professional Development (CPD) Programs</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://online.prc.gov.ph/Verification" target="_blank">Verify PRC Exam Rating</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://online.prc.gov.ph/Verification" target="_blank">Verify PRC License</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.prc.gov.ph/examination-result" target="_blank">View PRC Exam Results</a>
-                      </div>
-                    </div>
-                    <div id="section5" class="category">
-                      <h4>Salary Loans</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.dbp.ph/personal-banking/salary-loan/ec-credit-salary-loan/" target="_blank">Apply for EC Credit Salary Loan</a>
-                      </div>
-                    </div>
-                    <div id="section6" class="category">
-                      <h4>Union Association</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://blr-ours.dole.gov.ph/" target="_blank">Register Enterprised-based Union</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://blr.dole.gov.ph/2019/02/12/ouvp/" target="_blank">Verify Enterprised-based Union</a>
-                      </div>
-                    </div>
+            <div class="col">
+              <div class="card h-100 shadow-sm hover-top text-center">
+                <a class="text-decoration-none" href="education.html">
+                  <div class="card-body px-4 py-5">
+                    <h6 class="fw-bold fs-2 heading-color mb-3">Education</h6>
+                    <p class="card-text text-secondary mb-4">Access scholarships, online courses, and government training.</p>
+                    <span class="fw-semibold text-primary">Explore services &rarr;</span>
                   </div>
-                </div>
+                </a>
               </div>
             </div>
-
-            <div class="accordion-item">
-              <h2 class="accordion-header" id="headingOne">
-                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseHealth" aria-expanded="true" aria-controls="collapseHealth">
-                  Health
-                </button>
-              </h2>
-              <div class="collapse" id="collapseHealth" data-bs-parent="#accordionExample">
-                <div class="card card-body">
-                  <div class="main-list">
-                    <div id="section1" class="category">
-                      <h4>Disaster-prone Areas</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.phivolcs.dost.gov.ph/" target="_blank">Check Volcanic Eruptions, Earthquakes, Tsunami and other related Geotectonic Phenomena</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://dromic.dswd.gov.ph/" target="_blank">Check DSWD Preparedness Response Online</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.phivolcs.dost.gov.ph/index.php/earthquake/earthquake-information3" target="_blank">Check Earthquake Information</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.phivolcs.dost.gov.ph/index.php/tsunami/tsunami-advisory-and-warning3" target="_blank">Check Tsunami Advisory and Warning</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.phivolcs.dost.gov.ph/index.php/volcano-hazard/volcano-bulletin2" target="_blank">Check Volcano Bulletins</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://hazardhunter.georisk.gov.ph/" target="_blank">Generate Initial Hazard Assessments in your Selected Location for Seismic, Volcanic, and Hydro-meteorological Hazards</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://geoanalytics.georisk.gov.ph/" target="_blank">Generate Summaries of Hazards and Risk Assessment and Perform Analysis and Visualization of Exposure and Elements at Risk to Natural Hazards</a>
-                      </div>
-                    </div>
-                    <div id="section2" class="category">
-                      <h4>Weather</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://philsensors.asti.dost.gov.ph/" target="_blank">Access Weather Data via PHILSENSORS</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://noah.up.edu.ph/#/" target="_blank">View Real-time Information on Hazards via Project NOAH</a>
-                      </div>
-                    </div>
+            <div class="col">
+              <div class="card h-100 shadow-sm hover-top text-center">
+                <a class="text-decoration-none" href="employment.html">
+                  <div class="card-body px-4 py-5">
+                    <h6 class="fw-bold fs-2 heading-color mb-3">Employment</h6>
+                    <p class="card-text text-secondary mb-4">Find jobs, manage licenses, and explore employment support.</p>
+                    <span class="fw-semibold text-primary">Explore services &rarr;</span>
                   </div>
-                </div>
+                </a>
               </div>
             </div>
-
-            <div class="accordion-item">
-              <h2 class="accordion-header" id="headingOne">
-                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseHousing" aria-expanded="true" aria-controls="collapseHousing">
-                  Housing
-                </button>
-              </h2>
-              <div class="collapse" id="collapseHousing" data-bs-parent="#accordionExample">
-                <div class="card card-body">
-                  <div class="main-list">
-                    <div id="section1" class="category">
-                      <h4>Housing Loans</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.pagibigfundservices.com/repricing/ " target="_blank">Apply for Pag-IBIG Conversion to Full Risk Based-Pricing (Re-Pricing)</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.pagibigfundservices.com/HousingLoan/Apply/Default.aspx" target="_blank">Apply for Pag-IBIG Housing Loan</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.pagibigfundservices.com/HLDeveloper/Account/Login.aspx" target="_blank">Apply for Pag-IBIG Housing Loan on Behalf of the Prospective Borrowers</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.pagibigfundservices.com/OnlineHLVerification/" target="_blank">Check Pag-IBIG Housing Loan Payments</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://nha.gov.ph/programs/" target="_blank">Look for Different Government Housing Programs</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.pagibigfundservices.com/virtualpagibig/OPF.aspx?PT=CL" target="_blank">Pay Pag-IBIG Calamity Loan Online</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.pagibigfundservices.com/virtualpagibig/OPF.aspx?PT=HL" target="_blank">Pay Pag-IBIG Housing Loan Online</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.pagibigfundservices.com/virtualpagibig/OPF.aspx?PT=HF" target="_blank">Pay Pag-IBIG Housing Loan Processing Fee Online</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.pagibigfundservices.com/virtualpagibig/OPF.aspx?PT=M2" target="_blank">Pay Pag-IBIG MP2 Savings (Voluntary Savings) Online</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.pagibigfundservices.com/virtualpagibig/OPF.aspx?PT=ST" target="_blank">Pay Pag-IBIG Multi-Purpose Loan Online</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.pagibigfundservices.com/virtualpagibig/OPF.aspx?PT=MC" target="_blank">Pay Pag-IBIG Regular Savings (Mandatory Contribution) Online</a>
-                      </div>
-                    </div>
-                    <div id="section2" class="category">
-                      <h4>Land Titles</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://eserbisyo.lra.gov.ph/" target="_blank">Apply for Land Titles</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://www.hgc.gov.ph/compute.html" target="_blank">Compute Monthly Amortization</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://dhsud.gov.ph/list-of-brokers-salespersons/" target="_blank">View List of Real Estate Brokers/Salespersons</a>
-                      </div>
-                    </div>
+            <div class="col">
+              <div class="card h-100 shadow-sm hover-top text-center">
+                <a class="text-decoration-none" href="health.html">
+                  <div class="card-body px-4 py-5">
+                    <h6 class="fw-bold fs-2 heading-color mb-3">Health &amp; Emergency</h6>
+                    <p class="card-text text-secondary mb-4">Get emergency hotlines, health advisories, and safety information.</p>
+                    <span class="fw-semibold text-primary">Explore services &rarr;</span>
                   </div>
-                </div>
+                </a>
               </div>
             </div>
-
-            <div class="accordion-item">
-              <h2 class="accordion-header" id="headingOne">
-                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapsePassport" aria-expanded="true" aria-controls="collapsePassport">
-                  Passport and Travel
-                </button>
-              </h2>
-              <div class="collapse" id="collapsePassport" data-bs-parent="#accordionExample">
-                <div class="card card-body">
-                  <div class="main-list">
-                    <div id="section1" class="category">
-                      <h4>Travel</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.dswd.gov.ph/eservices-3/" target="_blank">Apply Travel Clearance for Minors</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.passport.gov.ph/appointment" target="_blank">Schedule Passport Application Appointment</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.passport.gov.ph/appointment" target="_blank">Set Appointment for Passport Renewal</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://consular.dfa.gov.ph/services/consular-records/crd-requirements" target="_blank">View Requirements for Diplomatic and Official Passports Application</a>
-                      </div>
-                    </div>
-                    <div id="section2" class="category">
-                      <h4>Visa and Citizenship</h4>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/immigrant-visa/amendment-to-prv/amendment-to-prv-by-marriage" target="_blank">Amend Permanent Non-Quota Immigrant Visa by Marriage</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/immigrant-visa/amendment-to-prv/amendment-to-prv-proc-married-to-filipino" target="_blank">Amend Permanent Resident Visa of a Chinese National Married to a Filipino</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/services/citizenship-retention-and-aquisition/recognition-as-filipino-citizen" target="_blank">Apply for Recognition as Filipino Citizen</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/services/citizenship-retention-and-aquisition/application-for-retention-re-acquisition-of-phil-citizenship" target="_blank">Apply for Retention/ Re-acquisition of Philippine Citizenship</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/immigrant-visa/non-quota-visa/conversion-to-non-quota-immigrant-visa-by-marriage" target="_blank">Convert Non-Quota Immigrant Visa by Marriage</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/immigrant-visa/child-born-subsequent-to-the-issuance-of-immigrant-visa-of-the-accompanying-parent" target="_blank">Convert to Non-Quota Immigrant Visa of a Child Born Subsequent to the Issuance of Immigrant Visa of the Accompanying Parent</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/immigrant-visa/returning-formal-natural-born-filipino-citizen" target="_blank">Convert to Non-Quota Immigrant Visa of a Former Filipino Citizen Naturalized in a Foreign Country </a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/immigrant-visa/returning-resident" target="_blank">Convert to Non-Quota Immigrant Visa of a Previous Permanent Resident Returning from a Temporary Visit Abroad</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/immigrant-visa/child-born-abroad-of-immigrant-mother" target="_blank">Convert to Non-Quota Immigrant Visa of Child Born Abroad of an Immigrant Mother</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/immigrant-visa/amendment-to-prv/prv-for-proc" target="_blank">Convert to Permanent Resident Visa (Probationary) of a Chinese National Married to a Filipino Citizen</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/pre-arranged-employment-visa/conversion-to-pre-arranged-employee-commercial" target="_blank">Convert to Pre-arranged Employee Visa (Commercial)</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/pre-arranged-employment-visa/conversion-to-pre-arranged-employee-non-commercial" target="_blank">Convert to Pre-arranged Employee Visa (Non-Commercial)</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/immigrant-visa/quota-visa" target="_blank">Convert to Quota Immigrant Visa</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/student-visa/conversion-to-student-visa#" target="_blank">Convert to Student Visa</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/treaty-trader-or-treaty-investor/conversion-to-treaty-trader-or-treaty-investor" target="_blank">Convert to Treaty Trader's Visa or Treaty Investor's Visa </a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/temporary-resident-visa/conversion-to-trv-by-marriage" target="_blank">Convert to TRV by Marriage</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/temporary-resident-visa/conversion-to-trv-indian-married-to-filipino" target="_blank">Convert to TRV of an Indian National Married to a Filipino</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/temporary-visitor-visa/extension-of-authorized-stay-beyond-59-days" target="_blank">Extend Authorized Stay Beyond 59 Days</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/temporary-visitor-visa/long-stay-visitor-visa-extension-lsvve" target="_blank">Extend Long-Stay Visitor Visa</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/pre-arranged-employment-visa/extension-of-pre-arranged-employee-commercial" target="_blank">Extend Pre-arranged Employee Visa (Commercial)</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/pre-arranged-employment-visa/extension-of-pre-arranged-employee-non-commercial" target="_blank">Extend Pre-arranged Employee Visa (Non-Commercial)</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/student-visa/extension-of-student-visa" target="_blank">Extend Student Visa </a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/treaty-trader-or-treaty-investor/extension-of-treaty-trader-s-visa-treaty-investor-s-visa" target="_blank">Extend Treaty Trader's Visa / Treaty Investor's Visa</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/temporary-resident-visa/extension-of-trv-by-marriage" target="_blank">Extend TRV by Marriage</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/temporary-resident-visa/extension-of-trv-indian-married-to-filipino" target="_blank">Extend TRV of an Indian National Married to a Filipino</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/immigrant-visa/amendment-to-prv/prv-for-filipino-veterans" target="_blank">Get Permanent Resident Visa Grant for Filipino Veterans of World War II</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/pre-arranged-employment-visa/inclusion-of-dependent-in-the-pre-arranged-employee-visa-of-the-principal-holder" target="_blank">Include Dependent in a Pre-arranged Employee Visa</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/treaty-trader-or-treaty-investor/inclusion-of-dependent-in-the-treaty-trader-s-or-treaty-investor-s-visa-of-the-principal-holder" target="_blank">Include Dependent in The Treaty Trader / Treaty Investor Visa</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/immigrant-visa/non-quota-visa/inclusion-of-dependent" target="_blank">Include Dependent Spouse and/or Unmarried Child/ren below 21 years of age</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://cfo.ph/Online_PDOS_Account_Creation/" target="_blank">Reserve and Register to the Pre-Departure Orientation Seminar (PDOS) or Peer Counselling Session</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://cfo.ph/Online_EVP_Account_Creation/" target="_blank">Schedule an Appointment for Pre-Departure Orientation Seminar (PDOS) for participants of the Exchange Visitor Program under a J1 Visa</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://cfo.ph/Online_PDOS_Account_Creation-GCP/" target="_blank">Secure an Appointment for Guidance and Counselling Program (GCP) by the Commission on Filipinos Overseas (CFO)</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/accredited-official-of-foreign-government" target="_blank">View List of Accredited Official of Foreign Government Visa</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/temporary-visitor-visa/visa-waiver" target="_blank">Waive Visa</a>
-                      </div>
-                    </div>
+            <div class="col">
+              <div class="card h-100 shadow-sm hover-top text-center">
+                <a class="text-decoration-none" href="housing.html">
+                  <div class="card-body px-4 py-5">
+                    <h6 class="fw-bold fs-2 heading-color mb-3">Housing</h6>
+                    <p class="card-text text-secondary mb-4">Explore housing loans, amortizations, and land services.</p>
+                    <span class="fw-semibold text-primary">Explore services &rarr;</span>
                   </div>
-                </div>
+                </a>
               </div>
             </div>
-
-            <div class="accordion-item">
-              <h2 class="accordion-header" id="headingOne">
-                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseSocial" aria-expanded="true" aria-controls="collapseSocial">
-                  Social Services
-                </button>
-              </h2>
-              <div class="collapse" id="collapseSocial" data-bs-parent="#accordionExample">
-                <div class="card card-body">
-                  <div class="main-list">
-                    <div id="section1" class="category">
-                      <h4>Benefits Registration</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.sss.gov.ph/sss/appmanager/pages.jsp?page=howtoregister" target="_blank">Apply for SSS Number Online</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.sss.gov.ph/sss/appmanager/pages.jsp?page=retirementapplication" target="_blank">Apply for Technical Retirement</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://cec.philhealth.gov.ph/" target="_blank">Check Patient's PhilHealth Eligibility Status upon Admission</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.philhealth.gov.ph/partners/providers/institutional/map/" target="_blank">Locate Philhealth-accredited Health Care Institutions</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.sss.gov.ph/sss/appmanager/viewArticle.jsp?page=NR2018_023" target="_blank">Submit Maternity Notification via Text-SSS</a>
-                      </div>
-                    </div>
-                    <div id="section2" class="category">
-                      <h4>File Complaints</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://onlinelegalcounseling.1343actionline.ph/" target="_blank">Avail OFW Online Legal Counseling for Human Trafficking Victims, etc</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="http://ereklamo.dswd.gov.ph/index.php" target="_blank">File Complaints on DSWD Disaster-related initiatives</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.1343actionline.ph/report.html?view=form" target="_blank">File Human Trafficking Report</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://pcw.gov.ph/vawc-hotlines-during-community-quarantine/ " target="_blank">File Report for Violence Against Women and Children</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://1343actionline.ph/report/view/form" target="_blank">Inquire or Report a Human Trafficking Case or Incident</a>
-                      </div>
-                    </div>
-                    <div id="section3" class="category">
-                      <h4>Financial Assistance</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.dbp.ph/developmental-banking/infrastructure-and-logistics/water-for-every-resident-water-program/" target="_blank">Apply for DBP Water for Every Resident (WATER) Program</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.sss.gov.ph/" target="_blank">Apply for Small Business Wage Subsidy (SBWS) Online</a>
-                      </div>
-                    </div>
-                    <div id="section5" class="category">
-                      <h4>Salary Loans</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.sss.gov.ph/sss/appmanager/pages.jsp?page=salaryapplication" target="_blank">Certify Employee Salary Loan</a>
-                      </div>
-                    </div>
+            <div class="col">
+              <div class="card h-100 shadow-sm hover-top text-center">
+                <a class="text-decoration-none" href="passport-and-travel.html">
+                  <div class="card-body px-4 py-5">
+                    <h6 class="fw-bold fs-2 heading-color mb-3">Passport &amp; Travel</h6>
+                    <p class="card-text text-secondary mb-4">Apply for passports, visas, and travel clearances.</p>
+                    <span class="fw-semibold text-primary">Explore services &rarr;</span>
                   </div>
-                </div>
+                </a>
               </div>
             </div>
-
-            <div class="accordion-item">
-              <h2 class="accordion-header" id="headingOne">
-                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTax" aria-expanded="true" aria-controls="collapseTax">
-                 Tax
-                </button>
-              </h2>
-              <div class="collapse" id="collapseTax" data-bs-parent="#accordionExample">
-                <div class="card card-body">
-                  <div class="main-list">
-                    <div id="section1" class="category">
-                      <h4>Certificates</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://etspcert.bir.gov.ph/#/login" target="_blank">Apply and Process Certification of Electronic Tax Return Preparation, Filing and/or Payment Solutions</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.bir.gov.ph/index.php/tax-clearance/tax-clearance-application-form.html" target="_blank">Apply for BIR Tax Clearance Certificate</a>
-                      </div>
-                    </div>
-                    <div id="section2" class="category">
-                      <h4>Complaints</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.bir.gov.ph/index.php/eservices/ecomplaint-home.html" target="_blank">File Tax Complaints</a>
-                      </div>
-                    </div>
-                    <div id="section3" class="category">
-                      <h4>File Taxes</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.bir.gov.ph/index.php/tax-information/documentary-stamp-tax.html" target="_blank">Affix a Documentary Stamp on Taxable Documents</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://esales.bir.gov.ph/SALES/login.html" target="_blank">Report Gross Monthly Sales of Business Taxpayers</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://eorb.bir.gov.ph/eorb/" target="_blank">Submit Official Register Book of Goods and Products Subject to Excise Tax</a>
-                      </div>
-                    </div>
-                    <div id="section4" class="category">
-                      <h4>Register</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.bir.gov.ph/index.php/eservices/epay.html" target="_blank">File Tax Returns and Pay Taxes Online</a>
-                      </div>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.bir.gov.ph/index.php/registration-requirements/primary-registration/application-for-tin.html" target="_blank">Register for a Taxpayer Identification Number (TIN)</a>
-                      </div>
-                    </div>
-                    <div id="section5" class="category">
-                      <h4>Tax Calculation</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://taxcalculator.dof.gov.ph/" target="_blank">Calculate Withholding Tax</a>
-                      </div>
-                    </div>
+            <div class="col">
+              <div class="card h-100 shadow-sm hover-top text-center">
+                <a class="text-decoration-none" href="social-services.html">
+                  <div class="card-body px-4 py-5">
+                    <h6 class="fw-bold fs-2 heading-color mb-3">Social Services</h6>
+                    <p class="card-text text-secondary mb-4">Apply for aid, benefits, and citizen protection services.</p>
+                    <span class="fw-semibold text-primary">Explore services &rarr;</span>
                   </div>
-                </div>
+                </a>
               </div>
             </div>
-
-            <div class="accordion-item">
-              <h2 class="accordion-header" id="headingOne">
-                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTransport" aria-expanded="true" aria-controls="collapseTransport">
-                 Transport and Driving
-                </button>
-              </h2>
-              <div class="collapse" id="collapseTransport" data-bs-parent="#accordionExample">
-                <div class="card card-body">
-                  <div class="main-list">
-                    <div id="section1" class="category">
-                      <h4>License</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://lto.gov.ph/" target="_blank">Get a Driver's License</a>
-                      </div>
-                    </div>
-                    <div id="section2" class="category">
-                      <h4>Financial Assistance</h4>
-                      <div class="individual-service mb-2">
-                        <a href="https://www.dbp.ph/developmental-banking/infrastructure-and-logistics/connecting-rural-urban-intermodal-systems-efficiently-cruise/" target="_blank">Apply for DBP CRUISE Loan</a>
-                      </div>
-                    </div>
+            <div class="col">
+              <div class="card h-100 shadow-sm hover-top text-center">
+                <a class="text-decoration-none" href="tax.html">
+                  <div class="card-body px-4 py-5">
+                    <h6 class="fw-bold fs-2 heading-color mb-3">Tax</h6>
+                    <p class="card-text text-secondary mb-4">File returns, pay dues, and manage BIR online services.</p>
+                    <span class="fw-semibold text-primary">Explore services &rarr;</span>
                   </div>
-                </div>
+                </a>
               </div>
             </div>
-
+            <div class="col">
+              <div class="card h-100 shadow-sm hover-top text-center">
+                <a class="text-decoration-none" href="transport-and-driving.html">
+                  <div class="card-body px-4 py-5">
+                    <h6 class="fw-bold fs-2 heading-color mb-3">Transport &amp; Driving</h6>
+                    <p class="card-text text-secondary mb-4">Manage licenses, permits, and transport financing.</p>
+                    <span class="fw-semibold text-primary">Explore services &rarr;</span>
+                  </div>
+                </a>
+              </div>
+            </div>
           </div>
-        </div>    
+        </div>
       </section>
-
       <section class="py-0 bg-primary-gradient">
         <div class="bg-holder" style="background-image:url(assets/img/illustrations/footer-bg.png);background-position:center;background-size:cover;">
         </div>

--- a/passport-and-travel.html
+++ b/passport-and-travel.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en-US" dir="ltr">
+
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+
+    <!-- ===============================================-->
+    <!--    Document Title-->
+    <!-- ===============================================-->
+    <title>Passport &amp; Travel | PH Government Online</title>
+
+
+    <!-- ===============================================-->
+    <!--    Favicons-->
+    <!-- ===============================================-->
+    <link rel="apple-touch-icon" sizes="180x180" href="assets/img/favicons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/img/favicons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="assets/img/favicons/favicon-16x16.png">
+    <link rel="shortcut icon" type="image/x-icon" href="assets/img/favicons/favicon.ico">
+    <link rel="manifest" href="assets/img/favicons/manifest.json">
+    <meta name="msapplication-TileImage" content="assets/img/favicons/mstile-150x150.png">
+    <meta name="theme-color" content="#ffffff">
+
+
+    <!-- ===============================================-->
+    <!--    Stylesheets-->
+    <!-- ===============================================-->
+    <link href="assets/css/theme.css" rel="stylesheet" />
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VSNFJDN5JM"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-VSNFJDN5JM');
+    </script>
+  </head>
+
+
+  <body>
+
+    <!-- ===============================================-->
+    <!--    Main Content-->
+    <!-- ===============================================-->
+    <main class="main" id="top">
+      <nav class="navbar navbar-expand-lg navbar-light py-3 backdrop" data-navbar-on-scroll="data-navbar-on-scroll">
+        <div class="container"><a class="navbar-brand  mx-auto fw-bolder fs-2 fst-italic" href="index.html">
+           <img src="assets/img/logo.png" width="50px" alt="PH Online Services logo">
+            <span class="text-info">PH ONLINE</span>
+            <span class="text-warning">SERVICES</span>
+          </a>
+        </div>
+
+      </nav>
+
+      <section class="py-5 pt-0">
+        <div class="bg-holder d-none d-sm-block" style="background-image:url(assets/img/illustrations/category-bg.png);background-position:right top;background-size:200px 320px;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container mt-3">
+          <div class="row justify-content-center">
+            <div class="col-md-9 col-lg-8 text-center mb-3">
+              <h1 class="fw-bold fs-3 fs-lg-5 lh-sm mb-3">Passport &amp; Travel</h1>
+              <p class="mb-4">Schedule passport appointments, manage visa requirements and access travel documents for Filipinos and foreign visitors.</p>
+              <a class="btn btn-outline-primary btn-sm" href="index.html#categorieslist">&larr; Back to all categories</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-5">
+        <div class="container">
+          <div class="main-list">
+            <div class="category mb-5">
+              <h4 class="mb-3">Travel</h4>
+              <div class="individual-service mb-2"> <a href="https://www.dswd.gov.ph/eservices-3/" target="_blank" rel="noopener noreferrer">Apply Travel Clearance for Minors</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.passport.gov.ph/appointment" target="_blank" rel="noopener noreferrer">Schedule Passport Application Appointment</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.passport.gov.ph/appointment" target="_blank" rel="noopener noreferrer">Set Appointment for Passport Renewal</a> </div>
+              <div class="individual-service mb-2"> <a href="https://consular.dfa.gov.ph/services/consular-records/crd-requirements" target="_blank" rel="noopener noreferrer">View Requirements for Diplomatic and Official Passports Application</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Visa and Citizenship</h4>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/immigrant-visa/amendment-to-prv/amendment-to-prv-by-marriage" target="_blank" rel="noopener noreferrer">Amend Permanent Non-Quota Immigrant Visa by Marriage</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/immigrant-visa/amendment-to-prv/amendment-to-prv-proc-married-to-filipino" target="_blank" rel="noopener noreferrer">Amend Permanent Resident Visa of a Chinese National Married to a Filipino</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/services/citizenship-retention-and-aquisition/recognition-as-filipino-citizen" target="_blank" rel="noopener noreferrer">Apply for Recognition as Filipino Citizen</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/services/citizenship-retention-and-aquisition/application-for-retention-re-acquisition-of-phil-citizenship" target="_blank" rel="noopener noreferrer">Apply for Retention/ Re-acquisition of Philippine Citizenship</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/immigrant-visa/non-quota-visa/conversion-to-non-quota-immigrant-visa-by-marriage" target="_blank" rel="noopener noreferrer">Convert Non-Quota Immigrant Visa by Marriage</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/immigrant-visa/child-born-subsequent-to-the-issuance-of-immigrant-visa-of-the-accompanying-parent" target="_blank" rel="noopener noreferrer">Convert to Non-Quota Immigrant Visa of a Child Born Subsequent to the Issuance of Immigrant Visa of the Accompanying Parent</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/immigrant-visa/returning-formal-natural-born-filipino-citizen" target="_blank" rel="noopener noreferrer">Convert to Non-Quota Immigrant Visa of a Former Filipino Citizen Naturalized in a Foreign Country</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/immigrant-visa/returning-resident" target="_blank" rel="noopener noreferrer">Convert to Non-Quota Immigrant Visa of a Previous Permanent Resident Returning from a Temporary Visit Abroad</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/immigrant-visa/child-born-abroad-of-immigrant-mother" target="_blank" rel="noopener noreferrer">Convert to Non-Quota Immigrant Visa of Child Born Abroad of an Immigrant Mother</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/immigrant-visa/amendment-to-prv/prv-for-proc" target="_blank" rel="noopener noreferrer">Convert to Permanent Resident Visa (Probationary) of a Chinese National Married to a Filipino Citizen</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/pre-arranged-employment-visa/conversion-to-pre-arranged-employee-commercial" target="_blank" rel="noopener noreferrer">Convert to Pre-arranged Employee Visa (Commercial)</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/pre-arranged-employment-visa/conversion-to-pre-arranged-employee-non-commercial" target="_blank" rel="noopener noreferrer">Convert to Pre-arranged Employee Visa (Non-Commercial)</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/immigrant-visa/quota-visa" target="_blank" rel="noopener noreferrer">Convert to Quota Immigrant Visa</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/student-visa/conversion-to-student-visa#" target="_blank" rel="noopener noreferrer">Convert to Student Visa</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/treaty-trader-or-treaty-investor/conversion-to-treaty-trader-or-treaty-investor" target="_blank" rel="noopener noreferrer">Convert to Treaty Trader's Visa or Treaty Investor's Visa</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/temporary-resident-visa/conversion-to-trv-by-marriage" target="_blank" rel="noopener noreferrer">Convert to TRV by Marriage</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/temporary-resident-visa/conversion-to-trv-indian-married-to-filipino" target="_blank" rel="noopener noreferrer">Convert to TRV of an Indian National Married to a Filipino</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/temporary-visitor-visa/extension-of-authorized-stay-beyond-59-days" target="_blank" rel="noopener noreferrer">Extend Authorized Stay Beyond 59 Days</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/temporary-visitor-visa/long-stay-visitor-visa-extension-lsvve" target="_blank" rel="noopener noreferrer">Extend Long-Stay Visitor Visa</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/pre-arranged-employment-visa/extension-of-pre-arranged-employee-commercial" target="_blank" rel="noopener noreferrer">Extend Pre-arranged Employee Visa (Commercial)</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/pre-arranged-employment-visa/extension-of-pre-arranged-employee-non-commercial" target="_blank" rel="noopener noreferrer">Extend Pre-arranged Employee Visa (Non-Commercial)</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/student-visa/extension-of-student-visa" target="_blank" rel="noopener noreferrer">Extend Student Visa</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/treaty-trader-or-treaty-investor/extension-of-treaty-trader-s-visa-treaty-investor-s-visa" target="_blank" rel="noopener noreferrer">Extend Treaty Trader's Visa / Treaty Investor's Visa</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/temporary-resident-visa/extension-of-trv-by-marriage" target="_blank" rel="noopener noreferrer">Extend TRV by Marriage</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/temporary-resident-visa/extension-of-trv-indian-married-to-filipino" target="_blank" rel="noopener noreferrer">Extend TRV of an Indian National Married to a Filipino</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/immigrant-visa/amendment-to-prv/prv-for-filipino-veterans" target="_blank" rel="noopener noreferrer">Get Permanent Resident Visa Grant for Filipino Veterans of World War II</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/pre-arranged-employment-visa/inclusion-of-dependent-in-the-pre-arranged-employee-visa-of-the-principal-holder" target="_blank" rel="noopener noreferrer">Include Dependent in a Pre-arranged Employee Visa</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/treaty-trader-or-treaty-investor/inclusion-of-dependent-in-the-treaty-trader-s-or-treaty-investor-s-visa-of-the-principal-holder" target="_blank" rel="noopener noreferrer">Include Dependent in The Treaty Trader / Treaty Investor Visa</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/immigrant-visa/non-quota-visa/inclusion-of-dependent" target="_blank" rel="noopener noreferrer">Include Dependent Spouse and/or Unmarried Child/ren below 21 years of age</a> </div>
+              <div class="individual-service mb-2"> <a href="https://cfo.ph/Online_PDOS_Account_Creation/" target="_blank" rel="noopener noreferrer">Reserve and Register to the Pre-Departure Orientation Seminar (PDOS) or Peer Counselling Session</a> </div>
+              <div class="individual-service mb-2"> <a href="https://cfo.ph/Online_EVP_Account_Creation/" target="_blank" rel="noopener noreferrer">Schedule an Appointment for Pre-Departure Orientation Seminar (PDOS) for participants of the Exchange Visitor Program under a J1 Visa</a> </div>
+              <div class="individual-service mb-2"> <a href="https://cfo.ph/Online_PDOS_Account_Creation-GCP/" target="_blank" rel="noopener noreferrer">Secure an Appointment for Guidance and Counselling Program (GCP) by the Commission on Filipinos Overseas (CFO)</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/accredited-official-of-foreign-government" target="_blank" rel="noopener noreferrer">View List of Accredited Official of Foreign Government Visa</a> </div>
+              <div class="individual-service mb-2"> <a href="http://immigration.gov.ph/visa-requirements/non-immigrant-visa/temporary-visitor-visa/visa-waiver" target="_blank" rel="noopener noreferrer">Waive Visa</a> </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-0 bg-primary-gradient">
+        <div class="bg-holder" style="background-image:url(assets/img/illustrations/footer-bg.png);background-position:center;background-size:cover;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container">
+
+          <div class="row flex-center">
+            <div class="col-auto my-4">
+              <ul class="list-unstyled list-inline">
+                <li class="list-inline-item me-3"><a class="text-decoration-none" href="https://www.facebook.com/yudipotech/">
+                    <svg class="bi bi-facebook" xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="#1F3A63" viewBox="0 0 16 16">
+                      <path d="M16 8.049c0-4.446-3.582-8.05-8-8.05C3.58 0-.002 3.603-.002 8.05c0 4.017 2.926 7.347 6.75 7.951v-5.625h-2.03V8.05H6.75V6.275c0-2.017 1.195-3.131 3.022-3.131.876 0 1.791.157 1.791.157v1.98h-1.009c-.993 0-1.303.621-1.303 1.258v1.51h2.218l-.354 2.326H9.25V16c3.824-.604 6.75-3.934 6.75-7.951z"></path>
+                    </svg></a></li>
+              </ul>
+            </div>
+          </div>
+          <div class="row justify-content-center">
+            <div class="col-auto mb-2">
+              <p class="mb-0 fs--1 text-white my-2 text-center">&copy; 2022 YUDIPO TECH
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <!-- ===============================================-->
+    <!--    End of Main Content-->
+    <!-- ===============================================-->
+
+
+
+
+    <!-- ===============================================-->
+    <!--    JavaScripts-->
+    <!-- ===============================================-->
+    <script src="vendors/@popperjs/popper.min.js"></script>
+    <script src="vendors/bootstrap/bootstrap.min.js"></script>
+    <script src="vendors/is/is.min.js"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=window.scroll"></script>
+    <script src="assets/js/theme.js"></script>
+
+    <!-- Meta Pixel Code -->
+    <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '1556559851381406');
+      fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+      src="https://www.facebook.com/tr?id=1556559851381406&ev=PageView&noscript=1"
+    /></noscript>
+    <!-- End Meta Pixel Code -->
+
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,200;1,300;1,400&amp;display=swap" rel="stylesheet">
+  </body>
+
+</html>

--- a/social-services.html
+++ b/social-services.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en-US" dir="ltr">
+
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+
+    <!-- ===============================================-->
+    <!--    Document Title-->
+    <!-- ===============================================-->
+    <title>Social Services | PH Government Online</title>
+
+
+    <!-- ===============================================-->
+    <!--    Favicons-->
+    <!-- ===============================================-->
+    <link rel="apple-touch-icon" sizes="180x180" href="assets/img/favicons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/img/favicons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="assets/img/favicons/favicon-16x16.png">
+    <link rel="shortcut icon" type="image/x-icon" href="assets/img/favicons/favicon.ico">
+    <link rel="manifest" href="assets/img/favicons/manifest.json">
+    <meta name="msapplication-TileImage" content="assets/img/favicons/mstile-150x150.png">
+    <meta name="theme-color" content="#ffffff">
+
+
+    <!-- ===============================================-->
+    <!--    Stylesheets-->
+    <!-- ===============================================-->
+    <link href="assets/css/theme.css" rel="stylesheet" />
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VSNFJDN5JM"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-VSNFJDN5JM');
+    </script>
+  </head>
+
+
+  <body>
+
+    <!-- ===============================================-->
+    <!--    Main Content-->
+    <!-- ===============================================-->
+    <main class="main" id="top">
+      <nav class="navbar navbar-expand-lg navbar-light py-3 backdrop" data-navbar-on-scroll="data-navbar-on-scroll">
+        <div class="container"><a class="navbar-brand  mx-auto fw-bolder fs-2 fst-italic" href="index.html">
+           <img src="assets/img/logo.png" width="50px" alt="PH Online Services logo">
+            <span class="text-info">PH ONLINE</span>
+            <span class="text-warning">SERVICES</span>
+          </a>
+        </div>
+
+      </nav>
+
+      <section class="py-5 pt-0">
+        <div class="bg-holder d-none d-sm-block" style="background-image:url(assets/img/illustrations/category-bg.png);background-position:right top;background-size:200px 320px;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container mt-3">
+          <div class="row justify-content-center">
+            <div class="col-md-9 col-lg-8 text-center mb-3">
+              <h1 class="fw-bold fs-3 fs-lg-5 lh-sm mb-3">Social Services</h1>
+              <p class="mb-4">Find assistance programs, report welfare concerns and manage benefits from key Philippine social service agencies.</p>
+              <a class="btn btn-outline-primary btn-sm" href="index.html#categorieslist">&larr; Back to all categories</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-5">
+        <div class="container">
+          <div class="main-list">
+            <div class="category mb-5">
+              <h4 class="mb-3">Benefits Registration</h4>
+              <div class="individual-service mb-2"> <a href="https://www.sss.gov.ph/sss/appmanager/pages.jsp?page=howtoregister" target="_blank" rel="noopener noreferrer">Apply for SSS Number Online</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.sss.gov.ph/sss/appmanager/pages.jsp?page=retirementapplication" target="_blank" rel="noopener noreferrer">Apply for Technical Retirement</a> </div>
+              <div class="individual-service mb-2"> <a href="https://cec.philhealth.gov.ph/" target="_blank" rel="noopener noreferrer">Check Patient's PhilHealth Eligibility Status upon Admission</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.philhealth.gov.ph/partners/providers/institutional/map/" target="_blank" rel="noopener noreferrer">Locate PhilHealth-accredited Health Care Institutions</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.sss.gov.ph/sss/appmanager/viewArticle.jsp?page=NR2018_023" target="_blank" rel="noopener noreferrer">Submit Maternity Notification via Text-SSS</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">File Complaints</h4>
+              <div class="individual-service mb-2"> <a href="https://onlinelegalcounseling.1343actionline.ph/" target="_blank" rel="noopener noreferrer">Avail OFW Online Legal Counseling for Human Trafficking Victims</a> </div>
+              <div class="individual-service mb-2"> <a href="http://ereklamo.dswd.gov.ph/index.php" target="_blank" rel="noopener noreferrer">File Complaints on DSWD Disaster-related Initiatives</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.1343actionline.ph/report.html?view=form" target="_blank" rel="noopener noreferrer">File Human Trafficking Report</a> </div>
+              <div class="individual-service mb-2"> <a href="https://pcw.gov.ph/vawc-hotlines-during-community-quarantine/" target="_blank" rel="noopener noreferrer">File Report for Violence Against Women and Children</a> </div>
+              <div class="individual-service mb-2"> <a href="https://1343actionline.ph/report/view/form" target="_blank" rel="noopener noreferrer">Inquire or Report a Human Trafficking Case or Incident</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Financial Assistance</h4>
+              <div class="individual-service mb-2"> <a href="https://www.dbp.ph/developmental-banking/infrastructure-and-logistics/water-for-every-resident-water-program/" target="_blank" rel="noopener noreferrer">Apply for DBP Water for Every Resident (WATER) Program</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.sss.gov.ph/" target="_blank" rel="noopener noreferrer">Apply for Small Business Wage Subsidy (SBWS) Online</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Salary Loans</h4>
+              <div class="individual-service mb-2"> <a href="https://www.sss.gov.ph/sss/appmanager/pages.jsp?page=salaryapplication" target="_blank" rel="noopener noreferrer">Certify Employee Salary Loan</a> </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-0 bg-primary-gradient">
+        <div class="bg-holder" style="background-image:url(assets/img/illustrations/footer-bg.png);background-position:center;background-size:cover;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container">
+
+          <div class="row flex-center">
+            <div class="col-auto my-4">
+              <ul class="list-unstyled list-inline">
+                <li class="list-inline-item me-3"><a class="text-decoration-none" href="https://www.facebook.com/yudipotech/">
+                    <svg class="bi bi-facebook" xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="#1F3A63" viewBox="0 0 16 16">
+                      <path d="M16 8.049c0-4.446-3.582-8.05-8-8.05C3.58 0-.002 3.603-.002 8.05c0 4.017 2.926 7.347 6.75 7.951v-5.625h-2.03V8.05H6.75V6.275c0-2.017 1.195-3.131 3.022-3.131.876 0 1.791.157 1.791.157v1.98h-1.009c-.993 0-1.303.621-1.303 1.258v1.51h2.218l-.354 2.326H9.25V16c3.824-.604 6.75-3.934 6.75-7.951z"></path>
+                    </svg></a></li>
+              </ul>
+            </div>
+          </div>
+          <div class="row justify-content-center">
+            <div class="col-auto mb-2">
+              <p class="mb-0 fs--1 text-white my-2 text-center">&copy; 2022 YUDIPO TECH
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <!-- ===============================================-->
+    <!--    End of Main Content-->
+    <!-- ===============================================-->
+
+
+
+
+    <!-- ===============================================-->
+    <!--    JavaScripts-->
+    <!-- ===============================================-->
+    <script src="vendors/@popperjs/popper.min.js"></script>
+    <script src="vendors/bootstrap/bootstrap.min.js"></script>
+    <script src="vendors/is/is.min.js"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=window.scroll"></script>
+    <script src="assets/js/theme.js"></script>
+
+    <!-- Meta Pixel Code -->
+    <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '1556559851381406');
+      fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+      src="https://www.facebook.com/tr?id=1556559851381406&ev=PageView&noscript=1"
+    /></noscript>
+    <!-- End Meta Pixel Code -->
+
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,200;1,300;1,400&amp;display=swap" rel="stylesheet">
+  </body>
+
+</html>

--- a/tax.html
+++ b/tax.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en-US" dir="ltr">
+
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+
+    <!-- ===============================================-->
+    <!--    Document Title-->
+    <!-- ===============================================-->
+    <title>Tax Services | PH Government Online</title>
+
+
+    <!-- ===============================================-->
+    <!--    Favicons-->
+    <!-- ===============================================-->
+    <link rel="apple-touch-icon" sizes="180x180" href="assets/img/favicons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/img/favicons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="assets/img/favicons/favicon-16x16.png">
+    <link rel="shortcut icon" type="image/x-icon" href="assets/img/favicons/favicon.ico">
+    <link rel="manifest" href="assets/img/favicons/manifest.json">
+    <meta name="msapplication-TileImage" content="assets/img/favicons/mstile-150x150.png">
+    <meta name="theme-color" content="#ffffff">
+
+
+    <!-- ===============================================-->
+    <!--    Stylesheets-->
+    <!-- ===============================================-->
+    <link href="assets/css/theme.css" rel="stylesheet" />
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VSNFJDN5JM"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-VSNFJDN5JM');
+    </script>
+  </head>
+
+
+  <body>
+
+    <!-- ===============================================-->
+    <!--    Main Content-->
+    <!-- ===============================================-->
+    <main class="main" id="top">
+      <nav class="navbar navbar-expand-lg navbar-light py-3 backdrop" data-navbar-on-scroll="data-navbar-on-scroll">
+        <div class="container"><a class="navbar-brand  mx-auto fw-bolder fs-2 fst-italic" href="index.html">
+           <img src="assets/img/logo.png" width="50px" alt="PH Online Services logo">
+            <span class="text-info">PH ONLINE</span>
+            <span class="text-warning">SERVICES</span>
+          </a>
+        </div>
+
+      </nav>
+
+      <section class="py-5 pt-0">
+        <div class="bg-holder d-none d-sm-block" style="background-image:url(assets/img/illustrations/category-bg.png);background-position:right top;background-size:200px 320px;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container mt-3">
+          <div class="row justify-content-center">
+            <div class="col-md-9 col-lg-8 text-center mb-3">
+              <h1 class="fw-bold fs-3 fs-lg-5 lh-sm mb-3">Tax Services</h1>
+              <p class="mb-4">File returns, apply for clearances, calculate withholding and manage BIR e-services for businesses and individuals.</p>
+              <a class="btn btn-outline-primary btn-sm" href="index.html#categorieslist">&larr; Back to all categories</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-5">
+        <div class="container">
+          <div class="main-list">
+            <div class="category mb-5">
+              <h4 class="mb-3">Certificates</h4>
+              <div class="individual-service mb-2"> <a href="https://etspcert.bir.gov.ph/#/login" target="_blank" rel="noopener noreferrer">Apply and Process Certification of Electronic Tax Return Preparation, Filing and/or Payment Solutions</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.bir.gov.ph/index.php/tax-clearance/tax-clearance-application-form.html" target="_blank" rel="noopener noreferrer">Apply for BIR Tax Clearance Certificate</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Complaints</h4>
+              <div class="individual-service mb-2"> <a href="https://www.bir.gov.ph/index.php/eservices/ecomplaint-home.html" target="_blank" rel="noopener noreferrer">File Tax Complaints</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">File Taxes</h4>
+              <div class="individual-service mb-2"> <a href="https://www.bir.gov.ph/index.php/tax-information/documentary-stamp-tax.html" target="_blank" rel="noopener noreferrer">Affix a Documentary Stamp on Taxable Documents</a> </div>
+              <div class="individual-service mb-2"> <a href="https://esales.bir.gov.ph/SALES/login.html" target="_blank" rel="noopener noreferrer">Report Gross Monthly Sales of Business Taxpayers</a> </div>
+              <div class="individual-service mb-2"> <a href="https://eorb.bir.gov.ph/eorb/" target="_blank" rel="noopener noreferrer">Submit Official Register Book of Goods and Products Subject to Excise Tax</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Register</h4>
+              <div class="individual-service mb-2"> <a href="https://www.bir.gov.ph/index.php/eservices/epay.html" target="_blank" rel="noopener noreferrer">File Tax Returns and Pay Taxes Online</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.bir.gov.ph/index.php/registration-requirements/primary-registration/application-for-tin.html" target="_blank" rel="noopener noreferrer">Register for a Taxpayer Identification Number (TIN)</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Tax Calculation</h4>
+              <div class="individual-service mb-2"> <a href="https://taxcalculator.dof.gov.ph/" target="_blank" rel="noopener noreferrer">Calculate Withholding Tax</a> </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-0 bg-primary-gradient">
+        <div class="bg-holder" style="background-image:url(assets/img/illustrations/footer-bg.png);background-position:center;background-size:cover;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container">
+
+          <div class="row flex-center">
+            <div class="col-auto my-4">
+              <ul class="list-unstyled list-inline">
+                <li class="list-inline-item me-3"><a class="text-decoration-none" href="https://www.facebook.com/yudipotech/">
+                    <svg class="bi bi-facebook" xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="#1F3A63" viewBox="0 0 16 16">
+                      <path d="M16 8.049c0-4.446-3.582-8.05-8-8.05C3.58 0-.002 3.603-.002 8.05c0 4.017 2.926 7.347 6.75 7.951v-5.625h-2.03V8.05H6.75V6.275c0-2.017 1.195-3.131 3.022-3.131.876 0 1.791.157 1.791.157v1.98h-1.009c-.993 0-1.303.621-1.303 1.258v1.51h2.218l-.354 2.326H9.25V16c3.824-.604 6.75-3.934 6.75-7.951z"></path>
+                    </svg></a></li>
+              </ul>
+            </div>
+          </div>
+          <div class="row justify-content-center">
+            <div class="col-auto mb-2">
+              <p class="mb-0 fs--1 text-white my-2 text-center">&copy; 2022 YUDIPO TECH
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <!-- ===============================================-->
+    <!--    End of Main Content-->
+    <!-- ===============================================-->
+
+
+
+
+    <!-- ===============================================-->
+    <!--    JavaScripts-->
+    <!-- ===============================================-->
+    <script src="vendors/@popperjs/popper.min.js"></script>
+    <script src="vendors/bootstrap/bootstrap.min.js"></script>
+    <script src="vendors/is/is.min.js"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=window.scroll"></script>
+    <script src="assets/js/theme.js"></script>
+
+    <!-- Meta Pixel Code -->
+    <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '1556559851381406');
+      fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+      src="https://www.facebook.com/tr?id=1556559851381406&ev=PageView&noscript=1"
+    /></noscript>
+    <!-- End Meta Pixel Code -->
+
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,200;1,300;1,400&amp;display=swap" rel="stylesheet">
+  </body>
+
+</html>

--- a/transport-and-driving.html
+++ b/transport-and-driving.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en-US" dir="ltr">
+
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+
+    <!-- ===============================================-->
+    <!--    Document Title-->
+    <!-- ===============================================-->
+    <title>Transport &amp; Driving | PH Government Online</title>
+
+
+    <!-- ===============================================-->
+    <!--    Favicons-->
+    <!-- ===============================================-->
+    <link rel="apple-touch-icon" sizes="180x180" href="assets/img/favicons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/img/favicons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="assets/img/favicons/favicon-16x16.png">
+    <link rel="shortcut icon" type="image/x-icon" href="assets/img/favicons/favicon.ico">
+    <link rel="manifest" href="assets/img/favicons/manifest.json">
+    <meta name="msapplication-TileImage" content="assets/img/favicons/mstile-150x150.png">
+    <meta name="theme-color" content="#ffffff">
+
+
+    <!-- ===============================================-->
+    <!--    Stylesheets-->
+    <!-- ===============================================-->
+    <link href="assets/css/theme.css" rel="stylesheet" />
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VSNFJDN5JM"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-VSNFJDN5JM');
+    </script>
+  </head>
+
+
+  <body>
+
+    <!-- ===============================================-->
+    <!--    Main Content-->
+    <!-- ===============================================-->
+    <main class="main" id="top">
+      <nav class="navbar navbar-expand-lg navbar-light py-3 backdrop" data-navbar-on-scroll="data-navbar-on-scroll">
+        <div class="container"><a class="navbar-brand  mx-auto fw-bolder fs-2 fst-italic" href="index.html">
+           <img src="assets/img/logo.png" width="50px" alt="PH Online Services logo">
+            <span class="text-info">PH ONLINE</span>
+            <span class="text-warning">SERVICES</span>
+          </a>
+        </div>
+
+      </nav>
+
+      <section class="py-5 pt-0">
+        <div class="bg-holder d-none d-sm-block" style="background-image:url(assets/img/illustrations/category-bg.png);background-position:right top;background-size:200px 320px;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container mt-3">
+          <div class="row justify-content-center">
+            <div class="col-md-9 col-lg-8 text-center mb-3">
+              <h1 class="fw-bold fs-3 fs-lg-5 lh-sm mb-3">Transport &amp; Driving</h1>
+              <p class="mb-4">Access LTO licensing services and government loan programs that support transport and logistics initiatives.</p>
+              <a class="btn btn-outline-primary btn-sm" href="index.html#categorieslist">&larr; Back to all categories</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-5">
+        <div class="container">
+          <div class="main-list">
+            <div class="category mb-5">
+              <h4 class="mb-3">License</h4>
+              <div class="individual-service mb-2"> <a href="https://lto.gov.ph/" target="_blank" rel="noopener noreferrer">Get a Driver's License</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Financial Assistance</h4>
+              <div class="individual-service mb-2"> <a href="https://www.dbp.ph/developmental-banking/infrastructure-and-logistics/connecting-rural-urban-intermodal-systems-efficiently-cruise/" target="_blank" rel="noopener noreferrer">Apply for DBP CRUISE Loan</a> </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-0 bg-primary-gradient">
+        <div class="bg-holder" style="background-image:url(assets/img/illustrations/footer-bg.png);background-position:center;background-size:cover;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container">
+
+          <div class="row flex-center">
+            <div class="col-auto my-4">
+              <ul class="list-unstyled list-inline">
+                <li class="list-inline-item me-3"><a class="text-decoration-none" href="https://www.facebook.com/yudipotech/">
+                    <svg class="bi bi-facebook" xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="#1F3A63" viewBox="0 0 16 16">
+                      <path d="M16 8.049c0-4.446-3.582-8.05-8-8.05C3.58 0-.002 3.603-.002 8.05c0 4.017 2.926 7.347 6.75 7.951v-5.625h-2.03V8.05H6.75V6.275c0-2.017 1.195-3.131 3.022-3.131.876 0 1.791.157 1.791.157v1.98h-1.009c-.993 0-1.303.621-1.303 1.258v1.51h2.218l-.354 2.326H9.25V16c3.824-.604 6.75-3.934 6.75-7.951z"></path>
+                    </svg></a></li>
+              </ul>
+            </div>
+          </div>
+          <div class="row justify-content-center">
+            <div class="col-auto mb-2">
+              <p class="mb-0 fs--1 text-white my-2 text-center">&copy; 2022 YUDIPO TECH
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <!-- ===============================================-->
+    <!--    End of Main Content-->
+    <!-- ===============================================-->
+
+
+
+
+    <!-- ===============================================-->
+    <!--    JavaScripts-->
+    <!-- ===============================================-->
+    <script src="vendors/@popperjs/popper.min.js"></script>
+    <script src="vendors/bootstrap/bootstrap.min.js"></script>
+    <script src="vendors/is/is.min.js"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=window.scroll"></script>
+    <script src="assets/js/theme.js"></script>
+
+    <!-- Meta Pixel Code -->
+    <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '1556559851381406');
+      fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+      src="https://www.facebook.com/tr?id=1556559851381406&ev=PageView&noscript=1"
+    /></noscript>
+    <!-- End Meta Pixel Code -->
+
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,200;1,300;1,400&amp;display=swap" rel="stylesheet">
+  </body>
+
+</html>

--- a/weather.html
+++ b/weather.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en-US" dir="ltr">
+
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+
+    <!-- ===============================================-->
+    <!--    Document Title-->
+    <!-- ===============================================-->
+    <title>Weather &amp; Disaster Preparedness | PH Government Online</title>
+
+
+    <!-- ===============================================-->
+    <!--    Favicons-->
+    <!-- ===============================================-->
+    <link rel="apple-touch-icon" sizes="180x180" href="assets/img/favicons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/img/favicons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="assets/img/favicons/favicon-16x16.png">
+    <link rel="shortcut icon" type="image/x-icon" href="assets/img/favicons/favicon.ico">
+    <link rel="manifest" href="assets/img/favicons/manifest.json">
+    <meta name="msapplication-TileImage" content="assets/img/favicons/mstile-150x150.png">
+    <meta name="theme-color" content="#ffffff">
+
+
+    <!-- ===============================================-->
+    <!--    Stylesheets-->
+    <!-- ===============================================-->
+    <link href="assets/css/theme.css" rel="stylesheet" />
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VSNFJDN5JM"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-VSNFJDN5JM');
+    </script>
+  </head>
+
+
+  <body>
+
+    <!-- ===============================================-->
+    <!--    Main Content-->
+    <!-- ===============================================-->
+    <main class="main" id="top">
+      <nav class="navbar navbar-expand-lg navbar-light py-3 backdrop" data-navbar-on-scroll="data-navbar-on-scroll">
+        <div class="container"><a class="navbar-brand  mx-auto fw-bolder fs-2 fst-italic" href="index.html">
+           <img src="assets/img/logo.png" width="50px" alt="PH Online Services logo">
+            <span class="text-info">PH ONLINE</span>
+            <span class="text-warning">SERVICES</span>
+          </a>
+        </div>
+
+      </nav>
+
+      <section class="py-5 pt-0">
+        <div class="bg-holder d-none d-sm-block" style="background-image:url(assets/img/illustrations/category-bg.png);background-position:right top;background-size:200px 320px;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container mt-3">
+          <div class="row justify-content-center">
+            <div class="col-md-9 col-lg-8 text-center mb-3">
+              <h1 class="fw-bold fs-3 fs-lg-5 lh-sm mb-3">Weather &amp; Disaster Preparedness</h1>
+              <p class="mb-4">Monitor hazards, track severe weather and find government tools that help communities prepare for emergencies.</p>
+              <a class="btn btn-outline-primary btn-sm" href="index.html#categorieslist">&larr; Back to all categories</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-5">
+        <div class="container">
+          <div class="main-list">
+            <div class="category mb-5">
+              <h4 class="mb-3">Disaster-prone Areas</h4>
+              <div class="individual-service mb-2"> <a href="https://www.phivolcs.dost.gov.ph/" target="_blank" rel="noopener noreferrer">Check Volcanic Eruptions, Earthquakes, Tsunami and other related Geotectonic Phenomena</a> </div>
+              <div class="individual-service mb-2"> <a href="https://dromic.dswd.gov.ph/" target="_blank" rel="noopener noreferrer">Check DSWD Preparedness Response Online</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.phivolcs.dost.gov.ph/index.php/earthquake/earthquake-information3" target="_blank" rel="noopener noreferrer">Check Earthquake Information</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.phivolcs.dost.gov.ph/index.php/tsunami/tsunami-advisory-and-warning3" target="_blank" rel="noopener noreferrer">Check Tsunami Advisory and Warning</a> </div>
+              <div class="individual-service mb-2"> <a href="https://www.phivolcs.dost.gov.ph/index.php/volcano-hazard/volcano-bulletins3" target="_blank" rel="noopener noreferrer">Check Volcano Bulletins</a> </div>
+              <div class="individual-service mb-2"> <a href="https://hazardhunter.georisk.gov.ph/" target="_blank" rel="noopener noreferrer">Generate Initial Hazard Assessments in your Selected Location for Seismic, Volcanic, and Hydro-meteorological Hazards</a> </div>
+              <div class="individual-service mb-2"> <a href="https://geoanalytics.georisk.gov.ph/" target="_blank" rel="noopener noreferrer">Generate Summaries of Hazards and Risk Assessment and Perform Analysis and Visualization of Exposure and Elements at Risk to Natural Hazards</a> </div>
+            </div>
+            <div class="category mb-5">
+              <h4 class="mb-3">Weather</h4>
+              <div class="individual-service mb-2"> <a href="https://philsensors.asti.dost.gov.ph/" target="_blank" rel="noopener noreferrer">Access Weather Data via PHILSENSORS</a> </div>
+              <div class="individual-service mb-2"> <a href="https://noah.up.edu.ph/#/" target="_blank" rel="noopener noreferrer">View Real-time Information on Hazards via Project NOAH</a> </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-0 bg-primary-gradient">
+        <div class="bg-holder" style="background-image:url(assets/img/illustrations/footer-bg.png);background-position:center;background-size:cover;">
+        </div>
+        <!--/.bg-holder-->
+
+        <div class="container">
+
+          <div class="row flex-center">
+            <div class="col-auto my-4">
+              <ul class="list-unstyled list-inline">
+                <li class="list-inline-item me-3"><a class="text-decoration-none" href="https://www.facebook.com/yudipotech/">
+                    <svg class="bi bi-facebook" xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="#1F3A63" viewBox="0 0 16 16">
+                      <path d="M16 8.049c0-4.446-3.582-8.05-8-8.05C3.58 0-.002 3.603-.002 8.05c0 4.017 2.926 7.347 6.75 7.951v-5.625h-2.03V8.05H6.75V6.275c0-2.017 1.195-3.131 3.022-3.131.876 0 1.791.157 1.791.157v1.98h-1.009c-.993 0-1.303.621-1.303 1.258v1.51h2.218l-.354 2.326H9.25V16c3.824-.604 6.75-3.934 6.75-7.951z"></path>
+                    </svg></a></li>
+              </ul>
+            </div>
+          </div>
+          <div class="row justify-content-center">
+            <div class="col-auto mb-2">
+              <p class="mb-0 fs--1 text-white my-2 text-center">&copy; 2022 YUDIPO TECH
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <!-- ===============================================-->
+    <!--    End of Main Content-->
+    <!-- ===============================================-->
+
+
+
+
+    <!-- ===============================================-->
+    <!--    JavaScripts-->
+    <!-- ===============================================-->
+    <script src="vendors/@popperjs/popper.min.js"></script>
+    <script src="vendors/bootstrap/bootstrap.min.js"></script>
+    <script src="vendors/is/is.min.js"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=window.scroll"></script>
+    <script src="assets/js/theme.js"></script>
+
+    <!-- Meta Pixel Code -->
+    <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '1556559851381406');
+      fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+      src="https://www.facebook.com/tr?id=1556559851381406&ev=PageView&noscript=1"
+    /></noscript>
+    <!-- End Meta Pixel Code -->
+
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,200;1,300;1,400&amp;display=swap" rel="stylesheet">
+  </body>
+
+</html>


### PR DESCRIPTION
## Summary
- replace the homepage accordion with a grid of category cards that link to new standalone pages and refresh outdated quick-link URLs
- add dedicated HTML pages for each service category with consistent layouts and back-to-category navigation

## Testing
- Not Run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cb7ee4c6e48329a282a1f8687cdbb1